### PR TITLE
Implemented budgets

### DIFF
--- a/src/MuTalk-Model/MutationTestingAnalysis.class.st
+++ b/src/MuTalk-Model/MutationTestingAnalysis.class.st
@@ -11,7 +11,8 @@ Class {
 		'mutations',
 		'testCases',
 		'coverageAnalysisResult',
-		'logger'
+		'logger',
+		'budget'
 	],
 	#category : #'MuTalk-Model'
 }
@@ -24,6 +25,12 @@ MutationTestingAnalysis class >> defaultLogger [
 { #category : #defaults }
 MutationTestingAnalysis class >> defaultMutantsEvaluationStrategy [
 	^ AllTestsMethodsRunningTestSelectionStrategy new
+]
+
+{ #category : #defaults }
+MutationTestingAnalysis class >> defaultMutationTestingBudget [
+
+	^ MutationTestingFreeBudget new
 ]
 
 { #category : #defaults }
@@ -87,14 +94,41 @@ MutationTestingAnalysis class >> for: testCases mutating: classes using: operato
 ]
 
 { #category : #'instance creation' }
-MutationTestingAnalysis class >> for: testCases mutating: classes using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy loggingIn: aLogger [ 
+MutationTestingAnalysis class >> for: testCases mutating: classes using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy budget: aBudget [
+
+	^ self
+		  for: testCases
+		  mutating: classes
+		  using: operatorCollection
+		  with: aMutantsEvaluationStrategy
+		  with: aMutationsGenerationStrategy
+		  loggingIn: self defaultLogger
+		  budget: aBudget
+]
+
+{ #category : #'instance creation' }
+MutationTestingAnalysis class >> for: testCases mutating: classes using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy loggingIn: aLogger [
+
+	^ self
+		  for: testCases
+		  mutating: classes
+		  using: operatorCollection
+		  with: aMutantsEvaluationStrategy
+		  with: aMutationsGenerationStrategy
+		  loggingIn: aLogger
+		  budget: self defaultMutationTestingBudget
+]
+
+{ #category : #'instance creation' }
+MutationTestingAnalysis class >> for: testCases mutating: classes using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy loggingIn: aLogger budget: aBudget [
 	^ self new
 		initializeFor: testCases
 			mutating: classes
 			using: operatorCollection
 			with: aMutantsEvaluationStrategy
 			with: aMutationsGenerationStrategy
-			loggingIn: aLogger;
+			loggingIn: aLogger
+			budget: aBudget;
 		yourself
 ]
 
@@ -161,6 +195,18 @@ MutationTestingAnalysis class >> testCasesFrom: testClasses mutating: classes us
 ]
 
 { #category : #'instance creation' }
+MutationTestingAnalysis class >> testCasesFrom: testClasses mutating: classes using: operatorCollection with: anEvaluationStrategy with: aGenerationStrategy budget: aBudget [
+
+	^ self
+		  for: (self testCasesFrom: testClasses)
+		  mutating: classes
+		  using: operatorCollection
+		  with: anEvaluationStrategy
+		  with: aGenerationStrategy
+		  budget: aBudget
+]
+
+{ #category : #'instance creation' }
 MutationTestingAnalysis class >> testCasesFrom: testClasses mutating: classes using: operatorCollection with: anEvaluationStrategy with: aGenerationStrategy loggingIn: aLogger [ 
 	^ self 
 		for: (self testCasesFrom: testClasses)
@@ -213,16 +259,21 @@ MutationTestingAnalysis >> generateMutations [
 
 { #category : #running }
 MutationTestingAnalysis >> generateResults [
+
 	particularResults := OrderedCollection new.
+	budget start.
 	mutations
-		do: [:aMutation | logger logStartEvaluating: aMutation. 
+		do: [ :aMutation |
+			logger logStartEvaluating: aMutation.
 			particularResults add: (MutantEvaluation
-					for: aMutation
-					using: testCases
-					following: mutantsEvaluationStrategy
-					andConsidering: self coverageAnalysisResult) value]
-		displayingProgress:[ :aClass | 
-			'Evaluating Mutants: ', particularResults size asString , '/', mutations size asString ].
+					 for: aMutation
+					 using: testCases
+					 following: mutantsEvaluationStrategy
+					 andConsidering: self coverageAnalysisResult) value.
+			(budget check: particularResults) ifTrue: [ ^ particularResults ] ]
+		displayingProgress: [ :aClass |
+			'Evaluating Mutants: ' , particularResults size asString , '/'
+			, mutations size asString ].
 	^ particularResults
 ]
 
@@ -235,7 +286,8 @@ MutationTestingAnalysis >> initialTestRun [
 ]
 
 { #category : #'initialize-release' }
-MutationTestingAnalysis >> initializeFor: someTestCasesReferences mutating: someModelClasses using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy loggingIn: aLogger [ 
+MutationTestingAnalysis >> initializeFor: someTestCasesReferences mutating: someModelClasses using: operatorCollection with: aMutantsEvaluationStrategy with: aMutationsGenerationStrategy loggingIn: aLogger budget: aBudget [
+
 	modelClasses := someModelClasses.
 	testCases := someTestCasesReferences.
 	operators := operatorCollection.
@@ -243,7 +295,8 @@ MutationTestingAnalysis >> initializeFor: someTestCasesReferences mutating: some
 	mutantsEvaluationStrategy := aMutantsEvaluationStrategy.
 	particularResults := OrderedCollection new.
 	elapsedTime := 0.
-	logger := aLogger
+	logger := aLogger.
+	budget := aBudget
 ]
 
 { #category : #accesing }

--- a/src/MuTalk-Model/MutationTestingAnalysis.class.st
+++ b/src/MuTalk-Model/MutationTestingAnalysis.class.st
@@ -261,7 +261,6 @@ MutationTestingAnalysis >> generateMutations [
 MutationTestingAnalysis >> generateResults [
 
 	particularResults := OrderedCollection new.
-	budget start.
 	mutations
 		do: [ :aMutation |
 			logger logStartEvaluating: aMutation.
@@ -358,7 +357,8 @@ MutationTestingAnalysis >> run [
 	methods of
 	those classes) and execute all mutants in the set of testClases.
 	We obtain a result for each mutant generated"
-	^[self initialTestRun.
+	^[budget start.
+	self initialTestRun.
 	logger logAnalysisStartFor:self.
 	elapsedTime := Time millisecondsToRun: [
 					self generateCoverageAnalysis.

--- a/src/MuTalk-Model/MutationTestingBudget.class.st
+++ b/src/MuTalk-Model/MutationTestingBudget.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #MutationTestingBudget,
+	#superclass : #Object,
+	#instVars : [
+		'constraint'
+	],
+	#category : #'MuTalk-Model'
+}
+
+{ #category : #validation }
+MutationTestingBudget >> check: aCollection [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+MutationTestingBudget >> constraint [
+
+	^ constraint
+]
+
+{ #category : #accessing }
+MutationTestingBudget >> constraint: aConstraint [
+
+	constraint := aConstraint
+]
+
+{ #category : #accessing }
+MutationTestingBudget >> start [
+
+	^ self subclassResponsibility
+]

--- a/src/MuTalk-Model/MutationTestingFreeBudget.class.st
+++ b/src/MuTalk-Model/MutationTestingFreeBudget.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #MutationTestingFreeBudget,
+	#superclass : #MutationTestingBudget,
+	#category : #'MuTalk-Model'
+}
+
+{ #category : #accessing }
+MutationTestingFreeBudget >> start [
+
+	
+]

--- a/src/MuTalk-Model/MutationTestingFreeBudget.class.st
+++ b/src/MuTalk-Model/MutationTestingFreeBudget.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'MuTalk-Model'
 }
 
+{ #category : #validation }
+MutationTestingFreeBudget >> check: aCollection [
+
+	^ false
+]
+
 { #category : #accessing }
 MutationTestingFreeBudget >> start [
 

--- a/src/MuTalk-Model/MutationTestingTimeBudget.class.st
+++ b/src/MuTalk-Model/MutationTestingTimeBudget.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #MutationTestingTimeBudget,
+	#superclass : #MutationTestingBudget,
+	#instVars : [
+		'initialTime'
+	],
+	#category : #'MuTalk-Model'
+}
+
+{ #category : #validation }
+MutationTestingTimeBudget >> check: aCollection [
+
+	| currentTime |
+	currentTime := Time current.
+	^ (currentTime subtractTime: initialTime) >= constraint
+]
+
+{ #category : #accessing }
+MutationTestingTimeBudget >> start [
+
+	initialTime := Time current
+]

--- a/src/MuTalk-TestResources/AuxiliarClassForMutationTestingBudget.class.st
+++ b/src/MuTalk-TestResources/AuxiliarClassForMutationTestingBudget.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #AuxiliarClassForMutationTestingBudget,
+	#superclass : #Object,
+	#category : #'MuTalk-TestResources'
+}
+
+{ #category : #arithmetic }
+AuxiliarClassForMutationTestingBudget >> decrement: aNumber [
+
+	^ aNumber - 1
+]
+
+{ #category : #arithmetic }
+AuxiliarClassForMutationTestingBudget >> increment: aNumber [
+
+	^ aNumber + 1
+]

--- a/src/MuTalk-TestResources/AuxiliarTestClassForMutationTestingBudget.class.st
+++ b/src/MuTalk-TestResources/AuxiliarTestClassForMutationTestingBudget.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #AuxiliarTestClassForMutationTestingBudget,
+	#superclass : #TestCase,
+	#instVars : [
+		'object'
+	],
+	#category : #'MuTalk-TestResources'
+}
+
+{ #category : #running }
+AuxiliarTestClassForMutationTestingBudget >> setUp [
+	super setUp.
+
+	object := AuxiliarClassForMutationTestingBudget new.
+	(Duration seconds: 2) wait
+]
+
+{ #category : #tests }
+AuxiliarTestClassForMutationTestingBudget >> testDecrement [
+
+	self assert: (object decrement: 2) equals: 1
+]
+
+{ #category : #tests }
+AuxiliarTestClassForMutationTestingBudget >> testIncrement [
+
+	self assert: (object increment: 1) equals: 2
+]

--- a/src/MuTalk-Tests/MutationTestingBudgetTest.class.st
+++ b/src/MuTalk-Tests/MutationTestingBudgetTest.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #MutationTestingBudgetTest,
+	#superclass : #TestCase,
+	#category : #'MuTalk-Tests'
+}

--- a/src/MuTalk-Tests/MutationTestingTimeBudgetTest.class.st
+++ b/src/MuTalk-Tests/MutationTestingTimeBudgetTest.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : #MutationTestingTimeBudgetTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'budget',
+		'analysis'
+	],
+	#category : #'MuTalk-Tests'
+}
+
+{ #category : #running }
+MutationTestingTimeBudgetTest >> setUp [
+
+	| testCases classesToMutate |
+	super setUp.
+
+	testCases := { AuxiliarTestClassForMutationTestingBudget }.
+	classesToMutate := { AuxiliarClassForMutationTestingBudget }.
+
+	budget := MutationTestingTimeBudget new.
+
+	analysis := MutationTestingAnalysis
+		            testCasesFrom: testCases
+		            mutating: classesToMutate
+		            using: MutantOperator contents
+		            with: AllTestsMethodsRunningTestSelectionStrategy new
+		            with: AllMutantSelectionStrategy new
+		            budget: budget
+]
+
+{ #category : #tests }
+MutationTestingTimeBudgetTest >> test12SecShouldEvaluate2Mutants [
+
+	budget constraint: (Duration seconds: 12).
+	analysis run.
+	self
+		assert: analysis generalResult numberOfEvaluatedMutants
+		equals: 2
+]
+
+{ #category : #tests }
+MutationTestingTimeBudgetTest >> test13SecShouldEvaluate3Mutants [
+
+	budget constraint: (Duration seconds: 13).
+	analysis run.
+	self
+		assert: analysis generalResult numberOfEvaluatedMutants
+		equals: 3
+]
+
+{ #category : #tests }
+MutationTestingTimeBudgetTest >> test30SecShouldEvaluate4Mutants [
+
+	budget constraint: (Duration seconds: 30).
+	analysis run.
+	self
+		assert: analysis generalResult numberOfEvaluatedMutants
+		equals: 4
+]


### PR DESCRIPTION
Added budgets to represent a cost that an execution of MuTalk cannot exceed.
Currently there are ```MutationTestingFreeBudget```, which is essentially a budget with no constraint and do the same as before, without budgets, and ```MutationTestingTimeBudget```, which restrict the execution time with a time constraint.

In my implementation, the beggining of the timer is at the start of the ```run``` method rather than before the ```generateResults```, so it takes into account the time to run the tests a first time before evaluating the tests with the mutants.

Also, if the time constraint is exceeded while the tests are running against a mutant, the execution continues until all tests have finished, then the constraint blocks the next mutants from being evaluated.

An example of use:
![image](https://github.com/pharo-contributions/mutalk/assets/124769707/0fcda024-6c7f-4c0f-b659-f14d3c8264c8)