### PR TITLE
Added test for not exact percentage mutant selection

### DIFF
--- a/src/MuTalk-Tests/MutationTestingPercentageOfMutantsBudgetTest.class.st
+++ b/src/MuTalk-Tests/MutationTestingPercentageOfMutantsBudgetTest.class.st
@@ -32,16 +32,6 @@ MutationTestingPercentageOfMutantsBudgetTest >> testEvaluateAllMutantsWithMoreTh
 ]
 
 { #category : 'tests' }
-MutationTestingPercentageOfMutantsBudgetTest >> testEvaluateTheCorrectPercentageOfMutants [
-
-	self runAnalysisFor: 20.
-	self
-		assert:
-			analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100
-		equals: 20
-]
-
-{ #category : 'tests' }
 MutationTestingPercentageOfMutantsBudgetTest >> testEvaluateZeroPercentOfMutantsWithNegativePercentConstraint [
 
 	self runAnalysisFor: -10.
@@ -59,4 +49,25 @@ MutationTestingPercentageOfMutantsBudgetTest >> testEvaluateZeroPercentOfMutants
 		assert:
 			analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100
 		equals: 0
+]
+
+{ #category : 'tests' }
+MutationTestingPercentageOfMutantsBudgetTest >> testNonExactPercentageOfMutants [
+
+	self runAnalysisFor: 21.
+	self assert:
+		analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100 >= 21.
+	self
+		assert: analysis generalResult numberOfEvaluatedMutants
+		equals: 6
+]
+
+{ #category : 'tests' }
+MutationTestingPercentageOfMutantsBudgetTest >> testRoundPercentageOfMutants [
+
+	self runAnalysisFor: 20.
+	self
+		assert:
+			analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100
+		equals: 20
 ]

--- a/src/MuTalk-Tests/MutationTestingPercentageOfMutantsBudgetTest.class.st
+++ b/src/MuTalk-Tests/MutationTestingPercentageOfMutantsBudgetTest.class.st
@@ -52,6 +52,16 @@ MutationTestingPercentageOfMutantsBudgetTest >> testEvaluateZeroPercentOfMutants
 ]
 
 { #category : 'tests' }
+MutationTestingPercentageOfMutantsBudgetTest >> testExactPercentageOfMutants [
+
+	self runAnalysisFor: 20.
+	self
+		assert:
+			analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100
+		equals: 20
+]
+
+{ #category : 'tests' }
 MutationTestingPercentageOfMutantsBudgetTest >> testNonExactPercentageOfMutants [
 
 	self runAnalysisFor: 21.
@@ -60,14 +70,4 @@ MutationTestingPercentageOfMutantsBudgetTest >> testNonExactPercentageOfMutants 
 	self
 		assert: analysis generalResult numberOfEvaluatedMutants
 		equals: 6
-]
-
-{ #category : 'tests' }
-MutationTestingPercentageOfMutantsBudgetTest >> testRoundPercentageOfMutants [
-
-	self runAnalysisFor: 20.
-	self
-		assert:
-			analysis generalResult numberOfEvaluatedMutants / numberOfMutations * 100
-		equals: 20
 ]


### PR DESCRIPTION
Fixes #38
Added a test in case the percentage doesn't give an exact number of mutants (e.g. 5.25 mutants).
In this case, 6 mutants are evaluated, and the effective percentage of mutants evaluated is greater than the one given (it works the same way for time budget).