### PR TITLE
Disable epicea monitoring during mutant evaluation

### DIFF
--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -131,10 +131,12 @@ MethodMutation >> printOn: aStream [
 { #category : 'running' }
 MethodMutation >> runMutant [
 
-	^ [ 
+	| testResults |
+	EpMonitor disableDuring: [
+		[
 		self install.
-		self runTests
-	] ensure: [ self uninstall ]
+		testResults := self runTests ] ensure: [ self uninstall ] ].
+	^ testResults
 ]
 
 { #category : 'private' }

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -133,9 +133,9 @@ MethodMutation >> runMutantStoppingOnError: aBoolean [
 
 	| testResults |
 	EpMonitor disableDuring: [
-		self install.
+		[ self install.
 		testResults :=  self runTestsStoppingOnError: aBoolean
-  ] ensure: [ self uninstall ].
+  		] ensure: [ self uninstall ] ].
 	^ testResults
 ]
 


### PR DESCRIPTION
Code changes is not polluted by the mutants.