### PR TITLE
Allow analysis to continue even after the first test error

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -10,5 +10,8 @@ SmalltalkCISpec {
         #coverage : {
             #packages : [ 'MuTalk*' ]
         }
+        #exclude : {
+            #classes : [ #AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail ]
+        }
     }
 }

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -137,12 +137,29 @@ MethodMutation >> runMutant [
 	] ensure: [ self uninstall ]
 ]
 
+{ #category : 'running' }
+MethodMutation >> runMutantWithoutStoppingOnError [
+
+	^ [ 
+		self install.
+		self runTestsWithoutStoppingOnError
+	] ensure: [ self uninstall ]
+]
+
 { #category : 'private' }
 MethodMutation >> runTests [
 
 	^ (TestSuite named: 'Tests cases for: ' , self printString)
 		  addTests: testCaseReferences;
 		  runStoppingOnFirstFailOrError
+]
+
+{ #category : 'private' }
+MethodMutation >> runTestsWithoutStoppingOnError [
+
+	^ (TestSuite named: 'Tests cases for: ' , self printString)
+		  addTests: testCaseReferences;
+		  run
 ]
 
 { #category : 'private' }

--- a/src/MuTalk-Model/MethodMutation.class.st
+++ b/src/MuTalk-Model/MethodMutation.class.st
@@ -129,37 +129,22 @@ MethodMutation >> printOn: aStream [
 ]
 
 { #category : 'running' }
-MethodMutation >> runMutant [
+MethodMutation >> runMutantStoppingOnError: aBoolean [
 
-	^ [ 
-		self install.
-		self runTests
-	] ensure: [ self uninstall ]
-]
-
-{ #category : 'running' }
-MethodMutation >> runMutantWithoutStoppingOnError [
-
-	^ [ 
-		self install.
-		self runTestsWithoutStoppingOnError
-	] ensure: [ self uninstall ]
+	^ [
+	  self install.
+	  self runTestsStoppingOnError: aBoolean ] ensure: [ self uninstall ]
 ]
 
 { #category : 'private' }
-MethodMutation >> runTests [
+MethodMutation >> runTestsStoppingOnError: aBoolean [
 
-	^ (TestSuite named: 'Tests cases for: ' , self printString)
-		  addTests: testCaseReferences;
-		  runStoppingOnFirstFailOrError
-]
-
-{ #category : 'private' }
-MethodMutation >> runTestsWithoutStoppingOnError [
-
-	^ (TestSuite named: 'Tests cases for: ' , self printString)
-		  addTests: testCaseReferences;
-		  run
+	| testSuite |
+	testSuite := TestSuite named: 'Tests cases for: ' , self printString.
+	testSuite addTests: testCaseReferences.
+	^ aBoolean
+		  ifTrue: [ testSuite runStoppingOnFirstFailOrError ]
+		  ifFalse: [ testSuite run ]
 ]
 
 { #category : 'private' }

--- a/src/MuTalk-Model/MutantEvaluation.class.st
+++ b/src/MuTalk-Model/MutantEvaluation.class.st
@@ -74,27 +74,14 @@ MutantEvaluation >> testResults [
 ]
 
 { #category : 'evaluation' }
-MutantEvaluation >> value [
-	| testResults |
-	self initializeCoverageResultIfNil.
-
-	mutation testCaseReferences: (strategy testCasesToEvaluate: mutation for: self).
-	testResults := mutation runMutant.
-	^ MutantEvaluationResult
-		for: mutation
-		results: testResults
-		producedBy: self
-]
-
-{ #category : 'evaluation' }
-MutantEvaluation >> valueWithoutStoppingOnError [
+MutantEvaluation >> valueStoppingOnError: aBoolean [
 
 	| testResults |
 	self initializeCoverageResultIfNil.
 
 	mutation testCaseReferences:
 		(strategy testCasesToEvaluate: mutation for: self).
-	testResults := mutation runMutantWithoutStoppingOnError.
+	testResults := mutation runMutantStoppingOnError: aBoolean.
 	^ MutantEvaluationResult
 		  for: mutation
 		  results: testResults

--- a/src/MuTalk-Model/MutantEvaluation.class.st
+++ b/src/MuTalk-Model/MutantEvaluation.class.st
@@ -85,3 +85,18 @@ MutantEvaluation >> value [
 		results: testResults
 		producedBy: self
 ]
+
+{ #category : 'evaluation' }
+MutantEvaluation >> valueWithoutStoppingOnError [
+
+	| testResults |
+	self initializeCoverageResultIfNil.
+
+	mutation testCaseReferences:
+		(strategy testCasesToEvaluate: mutation for: self).
+	testResults := mutation runMutantWithoutStoppingOnError.
+	^ MutantEvaluationResult
+		  for: mutation
+		  results: testResults
+		  producedBy: self
+]

--- a/src/MuTalk-Model/MutationTestingAnalysis.class.st
+++ b/src/MuTalk-Model/MutationTestingAnalysis.class.st
@@ -12,7 +12,8 @@ Class {
 		'logger',
 		'budget',
 		'mutationsSelectionStrategy',
-		'mutantResults'
+		'mutantResults',
+		'stopOnErrorOrFail'
 	],
 	#category : 'MuTalk-Model',
 	#package : 'MuTalk-Model'
@@ -346,6 +347,12 @@ MutationTestingAnalysis >> coverageAnalysisResult: anObject [
 	coverageAnalysisResult := anObject
 ]
 
+{ #category : 'accessing' }
+MutationTestingAnalysis >> doNotStopOnErrorOrFail [
+
+	stopOnErrorOrFail := false
+]
+
 { #category : 'results' }
 MutationTestingAnalysis >> generalResult [
 	^ MutationTestingGeneralResult
@@ -370,16 +377,21 @@ MutationTestingAnalysis >> generateMutations [
 { #category : 'running' }
 MutationTestingAnalysis >> generateResults [
 
+	| mutantEvaluation |
 	mutantResults := OrderedCollection new.
 	mutations do: [ :aMutation |
-		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations) ifTrue: [
-			^ mutantResults ].
+		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
+			ifTrue: [ ^ mutantResults ].
 		logger logStartEvaluating: aMutation.
-		mutantResults add: (MutantEvaluation
-				 for: aMutation
-				 using: testCases
-				 following: mutantsEvaluationStrategy
-				 andConsidering: self coverageAnalysisResult) value ].
+		mutantEvaluation := MutantEvaluation
+			                    for: aMutation
+			                    using: testCases
+			                    following: mutantsEvaluationStrategy
+			                    andConsidering: self coverageAnalysisResult.
+
+		mutantResults add: (stopOnErrorOrFail
+				 ifTrue: [ mutantEvaluation value ]
+				 ifFalse: [ mutantEvaluation valueWithoutStoppingOnError ]) ].
 	^ mutantResults
 ]
 
@@ -402,7 +414,8 @@ MutationTestingAnalysis >> initializeFor: someTestCasesReferences mutating: some
 	mutantResults := OrderedCollection new.
 	elapsedTime := 0.
 	logger := aLogger.
-	budget := aBudget
+	budget := aBudget.
+	stopOnErrorOrFail := true
 ]
 
 { #category : 'accesing' }
@@ -476,6 +489,12 @@ MutationTestingAnalysis >> run [
 						do: [:ex | 
 							self inform: 'Your tests have Errors or Failures. Please correct them.'.
 							ex return: false]
+]
+
+{ #category : 'accessing' }
+MutationTestingAnalysis >> stopOnErrorOrFail: aBoolean [
+
+	stopOnErrorOrFail := aBoolean
 ]
 
 { #category : 'accesing' }

--- a/src/MuTalk-Model/MutationTestingAnalysis.class.st
+++ b/src/MuTalk-Model/MutationTestingAnalysis.class.st
@@ -377,21 +377,17 @@ MutationTestingAnalysis >> generateMutations [
 { #category : 'running' }
 MutationTestingAnalysis >> generateResults [
 
-	| mutantEvaluation |
 	mutantResults := OrderedCollection new.
 	mutations do: [ :aMutation |
 		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
 			ifTrue: [ ^ mutantResults ].
 		logger logStartEvaluating: aMutation.
-		mutantEvaluation := MutantEvaluation
-			                    for: aMutation
-			                    using: testCases
-			                    following: mutantsEvaluationStrategy
-			                    andConsidering: self coverageAnalysisResult.
-
-		mutantResults add: (stopOnErrorOrFail
-				 ifTrue: [ mutantEvaluation value ]
-				 ifFalse: [ mutantEvaluation valueWithoutStoppingOnError ]) ].
+		mutantResults add: ((MutantEvaluation
+				  for: aMutation
+				  using: testCases
+				  following: mutantsEvaluationStrategy
+				  andConsidering: self coverageAnalysisResult)
+				 valueStoppingOnError: stopOnErrorOrFail) ].
 	^ mutantResults
 ]
 

--- a/src/MuTalk-TestResources/AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail.class.st
+++ b/src/MuTalk-TestResources/AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : 'AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail',
+	#superclass : 'TestCase',
+	#classInstVars : [
+		'counter'
+	],
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}
+
+{ #category : 'accessing' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail class >> counter [
+
+	^ counter
+]
+
+{ #category : 'accessing' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail class >> counter: anObject [
+
+	counter := anObject
+]
+
+{ #category : 'accessing' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail class >> increment [
+
+	counter := counter + 1
+]
+
+{ #category : 'accessing' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail class >> reset [
+
+	counter := 0
+]
+
+{ #category : 'tests' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail >> testA [
+
+	self class increment.
+	self assert: self class counter < 4
+]
+
+{ #category : 'tests' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail >> testB [
+
+	self class increment.
+	self assert: self class counter < 4
+]
+
+{ #category : 'tests' }
+AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail >> testC [
+
+	self class increment.
+	self assert: self class counter < 4
+]

--- a/src/MuTalk-Tests/MethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MethodMutationTest.class.st
@@ -87,7 +87,7 @@ MethodMutationTest >> testMutationInfiniteLoop [
 			 for: #testIterativeFactorial
 			 in: FakeInfiniteLoopsTest) }.
 
-	res := methodMutation runMutant.
+	res := methodMutation runMutantStoppingOnError: true.
 
 	self assert: res errors size equals: 1
 ]
@@ -117,7 +117,7 @@ MethodMutationTest >> testMutationInfiniteRecursion [
 			 for: #testRecursiveFactorial
 			 in: FakeInfiniteLoopsTest) }.
 
-	res := methodMutation runMutant.
+	res := methodMutation runMutantStoppingOnError: true.
 
 	self assert: res errors size equals: 1
 ]
@@ -137,7 +137,7 @@ MethodMutationTest >> testMutationRun [
 		nodeNumber: 1
 		ofClass: AuxiliarClassForMutationTestingAnalysis.
 	methodMutation testCaseReferences: { TestCaseReference for: #simpleTestCaseRessource in: self class }.
-	res := methodMutation runMutant.
+	res := methodMutation runMutantStoppingOnError: true.
 
 	self assert: res runCount equals: 1
 ]

--- a/src/MuTalk-Tests/MutationTestingAnalysisTest.class.st
+++ b/src/MuTalk-Tests/MutationTestingAnalysisTest.class.st
@@ -198,3 +198,22 @@ MutationTestingAnalysisTest >> testExecutingTwoMutations [
 	results do: [ :mutationResult | self assert: mutationResult killed ].
 	self assert: generalResult numberOfKilledMutants = 2
 ]
+
+{ #category : 'tests' }
+MutationTestingAnalysisTest >> testRunningAllTests [
+	"This test verify that the test evaluation keeps running even after the first error, if specified"
+
+	| analysis |
+	analysis := MutationTestingAnalysis
+		            testCasesFrom: { AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail }
+		            mutating: { AuxiliarClassForMutationTestingAnalysis }
+		            using: MutantOperator contents.
+
+	analysis doNotStopOnErrorOrFail.
+	"In this class, tests fail after a certain of executions"
+	AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail reset.
+	analysis run.
+	"Counting the number of failed test for a mutant"
+	self assert:
+		analysis generalResult killedMutants first result failures size > 1
+]

--- a/src/MuTalk-Tests/NullMutation.class.st
+++ b/src/MuTalk-Tests/NullMutation.class.st
@@ -9,7 +9,7 @@ Class {
 }
 
 { #category : 'running' }
-NullMutation >> runMutant [
+NullMutation >> runMutantStoppingOnError: aBoolean [
 	
 	"I am a null mutation that does not run any tests and does not install any code.
 	Return an empty test result"

--- a/src/MuTalk-Tests/TestCasesSelectionStrategyTest.class.st
+++ b/src/MuTalk-Tests/TestCasesSelectionStrategyTest.class.st
@@ -14,7 +14,8 @@ TestCasesSelectionStrategyTest >> allTestsFromPackage [
 		with: TestClassForTestingCoverage
 		with: AuxiliarTestClassForTestingStrategies
 		with: AuxiliarClassForMutationTestingAnalysisTest
-		with: AuxiliarTestClassForMTBudget)
+		with: AuxiliarTestClassForMTBudget
+		with: AuxiliarTestClassForContinuingTestsExecutionAfterFirstFail)
 		inject: OrderedCollection new
 		into: [:tests :testClass | 
 			tests addAll: testClass suite tests.


### PR DESCRIPTION
Add an option to allow all the tests to be executed on mutants, even after the first error or fail.
Default behavior does not change.