### PR TITLE
Implemented test filters

### DIFF
--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -13,7 +13,8 @@ Class {
 		'mutantResults',
 		'stopOnErrorOrFail',
 		'testSelectionStrategy',
-		'mutantSelectionStrategy'
+		'mutantSelectionStrategy',
+		'testFilter'
 	],
 	#category : 'MuTalk-Model',
 	#package : 'MuTalk-Model'
@@ -486,6 +487,12 @@ MTAnalysis >> defaultOperators [
 ]
 
 { #category : 'accessing - defaults' }
+MTAnalysis >> defaultTestFilter [
+
+	^ MTFreeTestFilter new
+]
+
+{ #category : 'accessing - defaults' }
 MTAnalysis >> defaultTestSelectionStrategy [
 
 	^ MTAllTestsMethodsRunningTestSelectionStrategy new
@@ -525,14 +532,17 @@ MTAnalysis >> generateMutations [
 { #category : 'running' }
 MTAnalysis >> generateResults [
 
+	| tests |
 	mutantResults := OrderedCollection new.
+	tests := testFilter filterTests: testCases.
+
 	mutations do: [ :aMutation |
 		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
 			ifTrue: [ ^ mutantResults ].
 		logger logStartEvaluating: aMutation.
 		mutantResults add: ((MTMutantEvaluation
 				  for: aMutation
-				  using: testCases
+				  using: tests
 				  following: testSelectionStrategy
 				  andConsidering: self coverageAnalysisResult)
 				 valueStoppingOnError: stopOnErrorOrFail) ].
@@ -558,6 +568,7 @@ MTAnalysis >> initialize [
 	elapsedTime := 0.
 	logger := self defaultLogger.
 	budget := self defaultBudget.
+	testFilter := self defaultTestFilter.
 	stopOnErrorOrFail := true
 ]
 
@@ -693,6 +704,18 @@ MTAnalysis >> testCasesReferencesFrom: testClass [
 MTAnalysis >> testClasses: aClassCollection [
 
 	testCases := self testCasesFrom: aClassCollection
+]
+
+{ #category : 'accessing' }
+MTAnalysis >> testFilter [
+
+	^ testFilter
+]
+
+{ #category : 'accessing' }
+MTAnalysis >> testFilter: anObject [
+
+	testFilter := anObject
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Model/MTFreeTestFilter.class.st
+++ b/src/MuTalk-Model/MTFreeTestFilter.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTFreeTestFilter',
+	#superclass : 'MTTestFilter',
+	#category : 'MuTalk-Model-Test filters',
+	#package : 'MuTalk-Model',
+	#tag : 'Test filters'
+}
+
+{ #category : 'enumerating' }
+MTFreeTestFilter >> filterTests: aTestCaseCollection [
+
+	^ aTestCaseCollection
+]

--- a/src/MuTalk-Model/MTGeneralResult.class.st
+++ b/src/MuTalk-Model/MTGeneralResult.class.st
@@ -105,6 +105,12 @@ MTGeneralResult >> numberOfTerminatedMutants [
 	^ self terminatedMutants size
 ]
 
+{ #category : 'accessing' }
+MTGeneralResult >> particularResults [
+
+	^ particularResults
+]
+
 { #category : 'printing' }
 MTGeneralResult >> printDetailedInfoOn: aStream [ 
 	

--- a/src/MuTalk-Model/MTTestFilter.class.st
+++ b/src/MuTalk-Model/MTTestFilter.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : 'MTTestFilter',
+	#superclass : 'Object',
+	#instVars : [
+		'condition'
+	],
+	#category : 'MuTalk-Model-Test filters',
+	#package : 'MuTalk-Model',
+	#tag : 'Test filters'
+}
+
+{ #category : 'instance creation' }
+MTTestFilter class >> for: aCondition [
+
+	^ self new
+		  condition: aCondition;
+		  yourself
+]
+
+{ #category : 'accessing' }
+MTTestFilter >> condition [
+
+	^ condition
+]
+
+{ #category : 'accessing' }
+MTTestFilter >> condition: aCondition [
+
+	condition := aCondition
+]
+
+{ #category : 'enumerating' }
+MTTestFilter >> filterTests: aTestCaseCollection [
+
+	^ self subclassResponsibility
+]

--- a/src/MuTalk-Model/MTTimeTestFilter.class.st
+++ b/src/MuTalk-Model/MTTimeTestFilter.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTTimeTestFilter',
+	#superclass : 'MTTestFilter',
+	#category : 'MuTalk-Model-Test filters',
+	#package : 'MuTalk-Model',
+	#tag : 'Test filters'
+}
+
+{ #category : 'enumerating' }
+MTTimeTestFilter >> filterTests: aTestCaseCollection [
+
+	^ aTestCaseCollection select: [ :testCaseReference | testCaseReference lastTimeToRun <= condition ]
+]

--- a/src/MuTalk-Model/MTTimeTestFilter.class.st
+++ b/src/MuTalk-Model/MTTimeTestFilter.class.st
@@ -9,5 +9,6 @@ Class {
 { #category : 'enumerating' }
 MTTimeTestFilter >> filterTests: aTestCaseCollection [
 
-	^ aTestCaseCollection select: [ :testCaseReference | testCaseReference lastTimeToRun <= condition ]
+	^ aTestCaseCollection select: [ :testCaseReference |
+		  testCaseReference lastTimeToRun <= condition ]
 ]

--- a/src/MuTalk-TestResources/MTAuxiliarClassForTimeTestFilter.class.st
+++ b/src/MuTalk-TestResources/MTAuxiliarClassForTimeTestFilter.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : 'MTAuxiliarClassForTimeTestFilter',
+	#superclass : 'Object',
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}
+
+{ #category : 'accessing' }
+MTAuxiliarClassForTimeTestFilter >> simpleMethod [
+
+	^ 1 + 1
+]

--- a/src/MuTalk-TestResources/MTAuxiliarClassForTimeTestFilterTest.class.st
+++ b/src/MuTalk-TestResources/MTAuxiliarClassForTimeTestFilterTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'MTAuxiliarClassForTimeTestFilterTest',
+	#superclass : 'TestCase',
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}
+
+{ #category : 'tests' }
+MTAuxiliarClassForTimeTestFilterTest >> test10Milliseconds [
+
+	10 milliSeconds wait
+]
+
+{ #category : 'tests' }
+MTAuxiliarClassForTimeTestFilterTest >> test1Second [
+
+	1 second wait
+]

--- a/src/MuTalk-Tests/MTTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTTestFilterTest.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'MTTestFilterTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'analysis'
+	],
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'testing' }
+MTTestFilterTest class >> isAbstract [
+
+	^ self == MTTestFilterTest
+]
+
+{ #category : 'running' }
+MTTestFilterTest >> runAnalysisWithFilter: aTestFilter on: classesToMutate withTests: testCases [
+
+	analysis := MTAnalysis new
+		            testClasses: testCases;
+		            classesToMutate: classesToMutate;
+		            testFilter: aTestFilter.
+
+	analysis run
+]

--- a/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
@@ -1,0 +1,52 @@
+Class {
+	#name : 'MTTimeTestFilterTest',
+	#superclass : 'MTTestFilterTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'running' }
+MTTimeTestFilterTest >> runAnalysisForTimeCondition: aDuration [
+
+	self
+		runAnalysisWithFilter: (MTTimeTestFilter for: aDuration)
+		on: { MTAuxiliarClassForTimeTestFilter }
+		withTests: { MTAuxiliarClassForTimeTestFilterTest }
+]
+
+{ #category : 'running' }
+MTTimeTestFilterTest >> testWith10MillisecondsCondition [
+
+	| testCaseReference |
+	testCaseReference := MTTestCaseReference
+		                     for: #test10Milliseconds
+		                     in: MTAuxiliarClassForTimeTestFilterTest.
+	self runAnalysisForTimeCondition:
+		(self timeToRunFor: testCaseReference) * 10.
+
+	self
+		assert: (analysis generalResult particularResults at: 1) runCount
+		equals: 1
+]
+
+{ #category : 'running' }
+MTTimeTestFilterTest >> testWith1SecondCondition [
+
+	| testCaseReference |
+	testCaseReference := MTTestCaseReference
+		                     for: #test1Second
+		                     in: MTAuxiliarClassForTimeTestFilterTest.
+	self runAnalysisForTimeCondition:
+		(self timeToRunFor: testCaseReference) * 10.
+
+	self
+		assert: (analysis generalResult particularResults at: 1) runCount
+		equals: 2
+]
+
+{ #category : 'running' }
+MTTimeTestFilterTest >> timeToRunFor: aTestCaseReference [
+
+	aTestCaseReference runUnchecked.
+	^ aTestCaseReference lastTimeToRun
+]


### PR DESCRIPTION
Fixes #52
Added test filters as instance attribute of `MTAnalysis` to select which test cases will be used according to a condition.
Currently the only types of test filter are the `MTFreeTestFilter` which doesn't filter anything, and the `MTTimeTestFilter` which filters the tests that take more time than its condition.