### PR TITLE
New mutant operators

### DIFF
--- a/src/MuTalk-Model/MTAssignmentNullifierOperator.class.st
+++ b/src/MuTalk-Model/MTAssignmentNullifierOperator.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'MTAssignmentNullifierOperator',
+	#superclass : 'MTBlockBasedMutantOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'printing' }
+MTAssignmentNullifierOperator >> description [
+	
+	^ 'Nullify the value assigned'
+]
+
+{ #category : 'applying' }
+MTAssignmentNullifierOperator >> expressionToReplace [
+
+	^ [ :aNode | aNode isAssignment & aNode value isNotNil ]
+]
+
+{ #category : 'applying' }
+MTAssignmentNullifierOperator >> newExpression [
+
+	^ [ :anOldNode |
+	  | nodeCopy |
+	  nodeCopy := anOldNode copy.
+	  nodeCopy value: (RBLiteralValueNode value: nil).
+	  nodeCopy ]
+]

--- a/src/MuTalk-Model/MTReplaceWhileFalseReceiverOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileFalseReceiverOperator.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'MTReplaceWhileFalseReceiverOperator',
+	#superclass : 'MTReplaceReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'testing' }
+MTReplaceWhileFalseReceiverOperator class >> isAbstract [
+
+	^ self == MTReplaceWhileFalseReceiverOperator
+]
+
+{ #category : 'applying' }
+MTReplaceWhileFalseReceiverOperator >> selector [
+
+	^ #whileFalse:
+]

--- a/src/MuTalk-Model/MTReplaceWhileFalseReceiverWithFalseOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileFalseReceiverWithFalseOperator.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTReplaceWhileFalseReceiverWithFalseOperator',
+	#superclass : 'MTReplaceWhileFalseReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'applying' }
+MTReplaceWhileFalseReceiverWithFalseOperator >> newReceiverExpression [
+
+	^ 'false'
+]

--- a/src/MuTalk-Model/MTReplaceWhileFalseReceiverWithTrueOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileFalseReceiverWithTrueOperator.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTReplaceWhileFalseReceiverWithTrueOperator',
+	#superclass : 'MTReplaceWhileFalseReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'applying' }
+MTReplaceWhileFalseReceiverWithTrueOperator >> newReceiverExpression [
+
+	^ 'true'
+]

--- a/src/MuTalk-Model/MTReplaceWhileFalseWithWhileTrueMutantOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileFalseWithWhileTrueMutantOperator.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'MTReplaceWhileFalseWithWhileTrueMutantOperator',
+	#superclass : 'MTSelectorReplacementMutantOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperator >> newSelector [
+
+	^ #whileTrue:
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperator >> oldSelector [
+
+	^ #whileFalse:
+]

--- a/src/MuTalk-Model/MTReplaceWhileTrueReceiverOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileTrueReceiverOperator.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'MTReplaceWhileTrueReceiverOperator',
+	#superclass : 'MTReplaceReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'testing' }
+MTReplaceWhileTrueReceiverOperator class >> isAbstract [
+
+	^ self == MTReplaceWhileTrueReceiverOperator
+]
+
+{ #category : 'applying' }
+MTReplaceWhileTrueReceiverOperator >> selector [
+
+	^ #whileTrue:
+]

--- a/src/MuTalk-Model/MTReplaceWhileTrueReceiverWithFalseOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileTrueReceiverWithFalseOperator.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTReplaceWhileTrueReceiverWithFalseOperator',
+	#superclass : 'MTReplaceWhileTrueReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'applying' }
+MTReplaceWhileTrueReceiverWithFalseOperator >> newReceiverExpression [
+
+	^ 'false'
+]

--- a/src/MuTalk-Model/MTReplaceWhileTrueReceiverWithTrueOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileTrueReceiverWithTrueOperator.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'MTReplaceWhileTrueReceiverWithTrueOperator',
+	#superclass : 'MTReplaceWhileTrueReceiverOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'applying' }
+MTReplaceWhileTrueReceiverWithTrueOperator >> newReceiverExpression [
+
+	^ 'true'
+]

--- a/src/MuTalk-Model/MTReplaceWhileTrueWithWhileFalseMutantOperator.class.st
+++ b/src/MuTalk-Model/MTReplaceWhileTrueWithWhileFalseMutantOperator.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : 'MTReplaceWhileTrueWithWhileFalseMutantOperator',
+	#superclass : 'MTSelectorReplacementMutantOperator',
+	#category : 'MuTalk-Model-Operators',
+	#package : 'MuTalk-Model',
+	#tag : 'Operators'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperator >> newSelector [
+
+	^ #whileFalse:
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperator >> oldSelector [
+
+	^ #whileTrue:
+]

--- a/src/MuTalk-Tests/MTAssignmentNullifierOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTAssignmentNullifierOperatorTest.class.st
@@ -1,0 +1,56 @@
+Class {
+	#name : 'MTAssignmentNullifierOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithOneSender [
+
+	| i |
+	i := 1
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithOneSenderModified [
+
+	| i |
+	i := nil
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithTwoSenders [
+
+	| i j |
+	i := 1.
+	j := 2
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	| i j |
+	i := nil.
+	j := 2
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	| i j |
+	i := 1.
+	j := nil
+]
+
+{ #category : 'accessing' }
+MTAssignmentNullifierOperatorTest >> operator [
+
+	^ MTAssignmentNullifierOperator new
+]

--- a/src/MuTalk-Tests/MTEmptyMethodOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTEmptyMethodOperatorTest.class.st
@@ -24,12 +24,6 @@ MTEmptyMethodOperatorTest >> operator [
 	^ MTEmptyMethodOperator new
 ]
 
-{ #category : 'accessing' }
-MTEmptyMethodOperatorTest >> operatorDescription [
-
-	^ self operator  description
-]
-
 { #category : 'tests' }
 MTEmptyMethodOperatorTest >> testApplyMutantToMethod [
 

--- a/src/MuTalk-Tests/MTLiteralBooleanNegateOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTLiteralBooleanNegateOperatorTest.class.st
@@ -46,9 +46,3 @@ MTLiteralBooleanNegateOperatorTest >> operator [
 
 	^ MTLiteralBooleanNegateOperator new
 ]
-
-{ #category : 'accessing' }
-MTLiteralBooleanNegateOperatorTest >> operatorDescription [
-
-	^ self operator description 
-]

--- a/src/MuTalk-Tests/MTLiteralIntegersIncreaseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTLiteralIntegersIncreaseOperatorTest.class.st
@@ -49,9 +49,3 @@ MTLiteralIntegersIncreaseOperatorTest >> operator [
 
 	^ MTLiteralIntegersIncreaseOperator new
 ]
-
-{ #category : 'accessing' }
-MTLiteralIntegersIncreaseOperatorTest >> operatorDescription [
-
-	^ 'Increase a literal integer'
-]

--- a/src/MuTalk-Tests/MTMessageSendArguments1stNullifierOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTMessageSendArguments1stNullifierOperatorTest.class.st
@@ -61,9 +61,3 @@ MTMessageSendArguments1stNullifierOperatorTest >> operator [
 
 	^ MTMessageSendArguments1stNullifierOperator new
 ]
-
-{ #category : 'accessing' }
-MTMessageSendArguments1stNullifierOperatorTest >> operatorDescription [
-
-	^ self operator  description
-]

--- a/src/MuTalk-Tests/MTMessageSendArguments3rdNullifierOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTMessageSendArguments3rdNullifierOperatorTest.class.st
@@ -69,9 +69,3 @@ MTMessageSendArguments3rdNullifierOperatorTest >> operator [
 
 	^ MTMessageSendArguments3rdNullifierOperator new
 ]
-
-{ #category : 'accessing' }
-MTMessageSendArguments3rdNullifierOperatorTest >> operatorDescription [
-
-	^ self operator  description
-]

--- a/src/MuTalk-Tests/MTMessageSendToYourselfOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTMessageSendToYourselfOperatorTest.class.st
@@ -51,9 +51,3 @@ MTMessageSendToYourselfOperatorTest >> operator [
 
 	^ MTMessageSendToYourselfOperator new
 ]
-
-{ #category : 'accessing' }
-MTMessageSendToYourselfOperatorTest >> operatorDescription [
-
-	^ self operator  description
-]

--- a/src/MuTalk-Tests/MTMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTMutantOperatorTest.class.st
@@ -156,7 +156,8 @@ MTMutantOperatorTest >> operator [
 
 { #category : 'accessing' }
 MTMutantOperatorTest >> operatorDescription [
-	self subclassResponsibility 
+
+	^ self operator description
 ]
 
 { #category : 'tests' }

--- a/src/MuTalk-Tests/MTRemoveAtIfAbsentMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTRemoveAtIfAbsentMutantOperatorTest.class.st
@@ -49,8 +49,3 @@ MTRemoveAtIfAbsentMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTRemoveAtIfAbsentMutantOperatorTest >> operator [
 	^ MTRemoveAtIfAbsentOperator new
 ]
-
-{ #category : 'accessing' }
-MTRemoveAtIfAbsentMutantOperatorTest >> operatorDescription [
-	^ 'Remove at:ifAbsent:' 
-]

--- a/src/MuTalk-Tests/MTRemoveCaretMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTRemoveCaretMutantOperatorTest.class.st
@@ -46,8 +46,3 @@ MTRemoveCaretMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTRemoveCaretMutantOperatorTest >> operator [
 	^ MTRemoveCaretOperator new
 ]
-
-{ #category : 'accessing' }
-MTRemoveCaretMutantOperatorTest >> operatorDescription [
-	^ 'Remove ^' 
-]

--- a/src/MuTalk-Tests/MTRemoveExceptionHandlerOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTRemoveExceptionHandlerOperatorTest.class.st
@@ -43,8 +43,3 @@ MTRemoveExceptionHandlerOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTRemoveExceptionHandlerOperatorTest >> operator [
 	^ MTRemoveExceptionHandlerOperator new
 ]
-
-{ #category : 'accessing' }
-MTRemoveExceptionHandlerOperatorTest >> operatorDescription [
-	^ 'Remove Exception Handler Operator'
-]

--- a/src/MuTalk-Tests/MTReplaceAndArgumentWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndArgumentWithTrueOperatorTest.class.st
@@ -46,8 +46,3 @@ MTReplaceAndArgumentWithTrueOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndArgumentWithTrueOperatorTest >> operator [
 	^ MTReplaceAndArgumentWithTrueOperator new.
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndArgumentWithTrueOperatorTest >> operatorDescription [
-	^'Replace #and: argument with [true]'
-]

--- a/src/MuTalk-Tests/MTReplaceAndReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndReceiverWithTrueOperatorTest.class.st
@@ -46,8 +46,3 @@ MTReplaceAndReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndReceiverWithTrueOperatorTest >> operator [
 	^ MTReplaceAndReceiverWithTrueOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndReceiverWithTrueOperatorTest >> operatorDescription [
-	^'Replace #and: receiver with true'
-]

--- a/src/MuTalk-Tests/MTReplaceAndWithEqvMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndWithEqvMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceAndWithEqvMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndWithEqvMutantOperatorTest >> operator [
 	^ MTReplaceAndWithEqvMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndWithEqvMutantOperatorTest >> operatorDescription [
-	^'Replace #and: with #bEqv:'
-]

--- a/src/MuTalk-Tests/MTReplaceAndWithFalseMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndWithFalseMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceAndWithFalseMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndWithFalseMutantOperatorTest >> operator [
 	^ MTReplaceAndWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndWithFalseMutantOperatorTest >> operatorDescription [
-	^'Replace #and: with false'
-]

--- a/src/MuTalk-Tests/MTReplaceAndWithNandMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndWithNandMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceAndWithNandMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndWithNandMutantOperatorTest >> operator [
 	^ MTReplaceAndWithNandMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndWithNandMutantOperatorTest >> operatorDescription [
-	^'Replace #and: with #nand:'
-]

--- a/src/MuTalk-Tests/MTReplaceAndWithOrMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceAndWithOrMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceAndWithOrMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceAndWithOrMutantOperatorTest >> operator [
 	^ MTReplaceAndWithOrMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceAndWithOrMutantOperatorTest >> operatorDescription [
-	^'Replace #and: with #or:'
-]

--- a/src/MuTalk-Tests/MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperatorTest.class.st
@@ -66,8 +66,3 @@ MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperatorTest >> methodWithTwo
 MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperatorTest >> operator [
 	^ MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceDetectIfNoneFirstBlockWithAlwaysFalseBlockOperatorTest >> operatorDescription [ 
-	^'Replace detect: block with [:each | false] when #detect:ifNone: ' 
-]

--- a/src/MuTalk-Tests/MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperatorTest.class.st
@@ -66,8 +66,3 @@ MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperatorTest >> methodWithTwoS
 MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperatorTest >> operator [
 	^ MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceDetectIfNoneFirstBlockWithAlwaysTrueBlockOperatorTest >> operatorDescription [ 
-	^'Replace detect: block with [:each | true] when #detect:ifNone: ' 
-]

--- a/src/MuTalk-Tests/MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperatorTest.class.st
@@ -71,8 +71,3 @@ MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperatorTest >> methodWithTwoSende
 MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperatorTest >> operator [
 	^ MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceDetectIfNoneSecondBlockWithEmptyBlockOperatorTest >> operatorDescription [ 
-	^'Replace ifNone: block with [] when #detect:ifNone:'
-]

--- a/src/MuTalk-Tests/MTReplaceDoBlockWithEmptyBlockOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceDoBlockWithEmptyBlockOperatorTest.class.st
@@ -50,8 +50,3 @@ MTReplaceDoBlockWithEmptyBlockOperatorTest >> methodWithTwoSendersModifiedSecond
 MTReplaceDoBlockWithEmptyBlockOperatorTest >> operator [
 	^ MTReplaceDoBlockWithEmptyBlockOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceDoBlockWithEmptyBlockOperatorTest >> operatorDescription [
-	^'Replace do block with [:each |]'.
-]

--- a/src/MuTalk-Tests/MTReplaceGreaterOrEqualWithEqualMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceGreaterOrEqualWithEqualMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceGreaterOrEqualWithEqualMutantOperatorTest >> methodWithTwoSendersModifi
 MTReplaceGreaterOrEqualWithEqualMutantOperatorTest >> operator [
 	^ MTReplaceGreaterOrEqualWithEqualMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceGreaterOrEqualWithEqualMutantOperatorTest >> operatorDescription [
-	^'Replace #''>='' with #=' 
-]

--- a/src/MuTalk-Tests/MTReplaceGreaterOrEqualWithGreaterMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceGreaterOrEqualWithGreaterMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceGreaterOrEqualWithGreaterMutantOperatorTest >> methodWithTwoSendersModi
 MTReplaceGreaterOrEqualWithGreaterMutantOperatorTest >> operator [
 	^ MTReplaceGreaterOrEqualWithGreaterMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceGreaterOrEqualWithGreaterMutantOperatorTest >> operatorDescription [
-	^'Replace #''>='' with #>' 
-]

--- a/src/MuTalk-Tests/MTReplaceIfFalseReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfFalseReceiverWithFalseOperatorTest.class.st
@@ -48,8 +48,3 @@ MTReplaceIfFalseReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedSec
 MTReplaceIfFalseReceiverWithFalseOperatorTest >> operator [
 	^ MTReplaceIfFalseReceiverWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfFalseReceiverWithFalseOperatorTest >> operatorDescription [
-	^'Replace #ifFalse: receiver with false'
-]

--- a/src/MuTalk-Tests/MTReplaceIfFalseReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfFalseReceiverWithTrueOperatorTest.class.st
@@ -48,8 +48,3 @@ MTReplaceIfFalseReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedSeco
 MTReplaceIfFalseReceiverWithTrueOperatorTest >> operator [
 	^ MTReplaceIfFalseReceiverWithTrueOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfFalseReceiverWithTrueOperatorTest >> operatorDescription [
-	^'Replace #ifFalse: receiver with true'
-]

--- a/src/MuTalk-Tests/MTReplaceIfFalseWithIfTrueMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfFalseWithIfTrueMutantOperatorTest.class.st
@@ -47,8 +47,3 @@ MTReplaceIfFalseWithIfTrueMutantOperatorTest >> methodWithTwoSendersModifiedSeco
 MTReplaceIfFalseWithIfTrueMutantOperatorTest >> operator [
 	^ MTReplaceIfFalseWithIfTrueMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfFalseWithIfTrueMutantOperatorTest >> operatorDescription [
-	^'Replace #ifFalse: with #ifTrue:'
-]

--- a/src/MuTalk-Tests/MTReplaceIfTrueIfFalseReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfTrueIfFalseReceiverWithFalseOperatorTest.class.st
@@ -51,8 +51,3 @@ MTReplaceIfTrueIfFalseReceiverWithFalseOperatorTest >> methodWithTwoSendersModif
 MTReplaceIfTrueIfFalseReceiverWithFalseOperatorTest >> operator [
 	^ MTReplaceIfTrueIfFalseReceiverWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfTrueIfFalseReceiverWithFalseOperatorTest >> operatorDescription [
-	^'Replace #ifTrue:ifFalse: receiver with false'
-]

--- a/src/MuTalk-Tests/MTReplaceIfTrueIfFalseReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfTrueIfFalseReceiverWithTrueOperatorTest.class.st
@@ -51,8 +51,3 @@ MTReplaceIfTrueIfFalseReceiverWithTrueOperatorTest >> methodWithTwoSendersModifi
 MTReplaceIfTrueIfFalseReceiverWithTrueOperatorTest >> operator [
 	^ MTReplaceIfTrueIfFalseReceiverWithTrueOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfTrueIfFalseReceiverWithTrueOperatorTest >> operatorDescription [
-	^'Replace #ifTrue:ifFalse: receiver with true'
-]

--- a/src/MuTalk-Tests/MTReplaceIfTrueReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfTrueReceiverWithFalseOperatorTest.class.st
@@ -48,8 +48,3 @@ MTReplaceIfTrueReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedSeco
 MTReplaceIfTrueReceiverWithFalseOperatorTest >> operator [
 	^ MTReplaceIfTrueReceiverWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfTrueReceiverWithFalseOperatorTest >> operatorDescription [
-	^'Replace #ifTrue: receiver with false'
-]

--- a/src/MuTalk-Tests/MTReplaceIfTrueReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfTrueReceiverWithTrueOperatorTest.class.st
@@ -48,8 +48,3 @@ MTReplaceIfTrueReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedSecon
 MTReplaceIfTrueReceiverWithTrueOperatorTest >> operator [
 	^ MTReplaceIfTrueReceiverWithTrueOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfTrueReceiverWithTrueOperatorTest >> operatorDescription [
-	^'Replace #ifTrue: receiver with true'
-]

--- a/src/MuTalk-Tests/MTReplaceIfTrueWithIfFalseMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIfTrueWithIfFalseMutantOperatorTest.class.st
@@ -48,8 +48,3 @@ MTReplaceIfTrueWithIfFalseMutantOperatorTest >> methodWithTwoSendersModifiedSeco
 MTReplaceIfTrueWithIfFalseMutantOperatorTest >> operator [
 	^ MTReplaceIfTrueWithIfFalseMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIfTrueWithIfFalseMutantOperatorTest >> operatorDescription [
-	^'Replace #ifTrue: with #ifFalse:'
-]

--- a/src/MuTalk-Tests/MTReplaceIsEmptyWithNotEmptyMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceIsEmptyWithNotEmptyMutantOperatorTest.class.st
@@ -42,8 +42,3 @@ MTReplaceIsEmptyWithNotEmptyMutantOperatorTest >> methodWithTwoSendersModifiedSe
 MTReplaceIsEmptyWithNotEmptyMutantOperatorTest >> operator [
 	^MTReplaceIsEmptyWithNotEmptyMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceIsEmptyWithNotEmptyMutantOperatorTest >> operatorDescription [
-	^'Replace #isEmpty with #notEmpty'
-]

--- a/src/MuTalk-Tests/MTReplaceLessOrEqualWithEqualMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceLessOrEqualWithEqualMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceLessOrEqualWithEqualMutantOperatorTest >> methodWithTwoSendersModifiedS
 MTReplaceLessOrEqualWithEqualMutantOperatorTest >> operator [
 	^ MTReplaceLessOrEqualWithEqualMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceLessOrEqualWithEqualMutantOperatorTest >> operatorDescription [
-	^'Replace #''<='' with #=' 
-]

--- a/src/MuTalk-Tests/MTReplaceLessOrEqualWithLessMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceLessOrEqualWithLessMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceLessOrEqualWithLessMutantOperatorTest >> methodWithTwoSendersModifiedSe
 MTReplaceLessOrEqualWithLessMutantOperatorTest >> operator [
 	^ MTReplaceLessOrEqualWithLessMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceLessOrEqualWithLessMutantOperatorTest >> operatorDescription [
-	^'Replace #''<='' with #<' 
-]

--- a/src/MuTalk-Tests/MTReplaceMinusWithPlusMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceMinusWithPlusMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceMinusWithPlusMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceMinusWithPlusMutantOperatorTest >> operator [
 	^ MTReplaceMinusWithPlusMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceMinusWithPlusMutantOperatorTest >> operatorDescription [
-	^'Replace #- with #+'
-]

--- a/src/MuTalk-Tests/MTReplaceOrArgumentWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceOrArgumentWithFalseOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceOrArgumentWithFalseOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceOrArgumentWithFalseOperatorTest >> operator [
 	^ MTReplaceOrArgumentWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceOrArgumentWithFalseOperatorTest >> operatorDescription [
-	^'Replace #or: argument with [false]'
-]

--- a/src/MuTalk-Tests/MTReplaceOrReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceOrReceiverWithFalseOperatorTest.class.st
@@ -46,8 +46,3 @@ MTReplaceOrReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceOrReceiverWithFalseOperatorTest >> operator [
 	^ MTReplaceOrReceiverWithFalseOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceOrReceiverWithFalseOperatorTest >> operatorDescription [
-	^'Replace #or: receiver with false'
-]

--- a/src/MuTalk-Tests/MTReplaceOrWithAndMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceOrWithAndMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceOrWithAndMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceOrWithAndMutantOperatorTest >> operator [
 	^ MTReplaceOrWithAndMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceOrWithAndMutantOperatorTest >> operatorDescription [
-	^'Replace #or: with #and:'
-]

--- a/src/MuTalk-Tests/MTReplaceOrWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceOrWithTrueOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceOrWithTrueOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceOrWithTrueOperatorTest >> operator [
 	^ MTReplaceOrWithTrueOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceOrWithTrueOperatorTest >> operatorDescription [
-	^'Replace #or: with true'
-]

--- a/src/MuTalk-Tests/MTReplaceOrWithXorMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceOrWithXorMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplaceOrWithXorMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplaceOrWithXorMutantOperatorTest >> operator [
 	^ MTReplaceOrWithXorMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceOrWithXorMutantOperatorTest >> operatorDescription [
-	^'Replace #or: with #bXor:'
-]

--- a/src/MuTalk-Tests/MTReplacePlusWithMinusMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplacePlusWithMinusMutantOperatorTest.class.st
@@ -39,8 +39,3 @@ MTReplacePlusWithMinusMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
 MTReplacePlusWithMinusMutantOperatorTest >> operator [
 	^ MTReplacePlusWithMinusMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplacePlusWithMinusMutantOperatorTest >> operatorDescription [
-	^'Replace #+ with #-'
-]

--- a/src/MuTalk-Tests/MTReplaceRejectWithSelectMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceRejectWithSelectMutantOperatorTest.class.st
@@ -50,8 +50,3 @@ MTReplaceRejectWithSelectMutantOperatorTest >> methodWithTwoSendersModifiedSecon
 MTReplaceRejectWithSelectMutantOperatorTest >> operator [
 	^ MTReplaceRejectWithSelectMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceRejectWithSelectMutantOperatorTest >> operatorDescription [
-	^'Replace #reject: with #select:'
-]

--- a/src/MuTalk-Tests/MTReplaceSelectWithRejectMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceSelectWithRejectMutantOperatorTest.class.st
@@ -50,8 +50,3 @@ MTReplaceSelectWithRejectMutantOperatorTest >> methodWithTwoSendersModifiedSecon
 MTReplaceSelectWithRejectMutantOperatorTest >> operator [
 	^ MTReplaceSelectWithRejectMutantOperator new
 ]
-
-{ #category : 'accessing' }
-MTReplaceSelectWithRejectMutantOperatorTest >> operatorDescription [
-	^'Replace #select: with #reject:'
-]

--- a/src/MuTalk-Tests/MTReplaceWhileFalseReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileFalseReceiverWithFalseOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileFalseReceiverWithFalseOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithOneSender [
+
+	1 < 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithOneSenderModified [
+
+	false whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithTwoSenders [
+
+	1 < 2 whileFalse: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	false whileFalse: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 2 whileFalse: [  ].
+	false whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithFalseOperatorTest >> operator [
+
+	^ MTReplaceWhileFalseReceiverWithFalseOperator new
+]

--- a/src/MuTalk-Tests/MTReplaceWhileFalseReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileFalseReceiverWithTrueOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileFalseReceiverWithTrueOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithOneSender [
+
+	1 < 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithOneSenderModified [
+
+	true whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithTwoSenders [
+
+	1 < 2 whileFalse: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	true whileFalse: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 2 whileFalse: [  ].
+	true whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseReceiverWithTrueOperatorTest >> operator [
+
+	^ MTReplaceWhileFalseReceiverWithTrueOperator new
+]

--- a/src/MuTalk-Tests/MTReplaceWhileFalseWithWhileTrueMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileFalseWithWhileTrueMutantOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileFalseWithWhileTrueMutantOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithOneSender [
+
+	1 < 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithOneSenderModified [
+
+	1 < 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithTwoSenders [
+
+	1 < 2 whileFalse: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	1 < 2 whileTrue: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 2 whileFalse: [  ].
+	3 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileFalseWithWhileTrueMutantOperatorTest >> operator [
+
+	^ MTReplaceWhileFalseWithWhileTrueMutantOperator new
+]

--- a/src/MuTalk-Tests/MTReplaceWhileTrueReceiverWithFalseOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileTrueReceiverWithFalseOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileTrueReceiverWithFalseOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithOneSender [
+
+	1 < 1 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithOneSenderModified [
+
+	false whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithTwoSenders [
+
+	1 < 1 whileTrue: [  ].
+	1 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	false whileTrue: [  ].
+	1 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 1 whileTrue: [  ].
+	false whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithFalseOperatorTest >> operator [
+
+	^ MTReplaceWhileTrueReceiverWithFalseOperator new
+]

--- a/src/MuTalk-Tests/MTReplaceWhileTrueReceiverWithTrueOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileTrueReceiverWithTrueOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileTrueReceiverWithTrueOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithOneSender [
+
+	1 < 1 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithOneSenderModified [
+
+	true whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithTwoSenders [
+
+	1 < 1 whileTrue: [  ].
+	1 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	true whileTrue: [  ].
+	1 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 1 whileTrue: [  ].
+	true whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueReceiverWithTrueOperatorTest >> operator [
+
+	^ MTReplaceWhileTrueReceiverWithTrueOperator new 
+]

--- a/src/MuTalk-Tests/MTReplaceWhileTrueWithWhileFalseMutantOperatorTest.class.st
+++ b/src/MuTalk-Tests/MTReplaceWhileTrueWithWhileFalseMutantOperatorTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'MTReplaceWhileTrueWithWhileFalseMutantOperatorTest',
+	#superclass : 'MTMutantOperatorTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithNoSenders [
+
+	^ 1 + 2
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithOneSender [
+
+	1 < 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithOneSenderModified [
+
+	1 < 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithTwoSenders [
+
+	1 < 2 whileTrue: [  ].
+	3 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithTwoSendersModifiedFirst [
+
+	1 < 2 whileFalse: [  ].
+	3 > 2 whileTrue: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> methodWithTwoSendersModifiedSecond [
+
+	1 < 2 whileTrue: [  ].
+	3 > 2 whileFalse: [  ]
+]
+
+{ #category : 'accessing' }
+MTReplaceWhileTrueWithWhileFalseMutantOperatorTest >> operator [
+
+	^ MTReplaceWhileTrueWithWhileFalseMutantOperator new
+]


### PR DESCRIPTION
Added several mutant operators that were missing and could be interesting:
*  `MTAssignmentNullifierOperator` which transforms the value of an assignment to nil: `variable := value` -> `variable := nil`
* `MTReplaceWhileTrueWithWhileFalseMutantOperator` and `MTReplaceWhileFalseWithWhileTrueMutantOperator`
* `MTReplaceWhileTrueReceiverWithTrueOperator` and `MTReplaceWhileTrueReceiverWithFalseOperator`
* `MTReplaceWhileFalseReceiverWithTrueOperator` and `MTReplaceWhileFalseReceiverWithFalseOperator`