### PR TITLE
Updated file logger

### DIFF
--- a/src/MuTalk-Model/MTAnalysisFileLogger.class.st
+++ b/src/MuTalk-Model/MTAnalysisFileLogger.class.st
@@ -2,7 +2,7 @@ Class {
 	#name : 'MTAnalysisFileLogger',
 	#superclass : 'MTAnalysisLogger',
 	#instVars : [
-		'fileStream'
+		'fileReference'
 	],
 	#category : 'MuTalk-Model-Logging',
 	#package : 'MuTalk-Model',
@@ -16,22 +16,27 @@ MTAnalysisFileLogger class >> toFileNamed: aString [
 
 { #category : 'initialize-release' }
 MTAnalysisFileLogger >> initializeToFileNamed: aString [
-	fileStream := FileStream forceNewFileNamed: aString.
+
+	fileReference := aString asFileReference
 ]
 
 { #category : 'logging' }
-MTAnalysisFileLogger >> logAnalysisStartFor: aMutationTestingAnalysis [ 
-	self writeLineToFile: 'The analysis is starting...'.
+MTAnalysisFileLogger >> logAnalysisStartFor: aMutationTestingAnalysis [
+
+	self writeLineToFile: 'The analysis is starting...'
 ]
 
 { #category : 'logging' }
-MTAnalysisFileLogger >> logStartBuildingMutantionsFor: aCompiledMethod using: aMutantOperator [ 
-	self writeLineToFile: 'Generating mutations for '
-			, (self methodNameOf: aCompiledMethod) , '  With operator:' , aMutantOperator description
+MTAnalysisFileLogger >> logStartBuildingMutantionsFor: aCompiledMethod using: aMutantOperator [
+
+	self writeLineToFile:
+		'Generating mutations for ' , (self methodNameOf: aCompiledMethod)
+		, '  With operator:' , aMutantOperator description
 ]
 
 { #category : 'logging' }
 MTAnalysisFileLogger >> logStartEvaluating: aMethodMutation [
+
 	| logStream |
 	logStream := WriteStream on: String new.
 	logStream
@@ -44,14 +49,18 @@ MTAnalysisFileLogger >> logStartEvaluating: aMethodMutation [
 ]
 
 { #category : 'private' }
-MTAnalysisFileLogger >> methodNameOf: aCompiledMethod [ 
-	^aCompiledMethod methodClass name asString , '>>' , aCompiledMethod selector printString 
+MTAnalysisFileLogger >> methodNameOf: aCompiledMethod [
+
+	^ aCompiledMethod methodClass name asString , '>>'
+	  , aCompiledMethod selector printString
 ]
 
 { #category : 'private' }
-MTAnalysisFileLogger >> writeLineToFile: aString [ 
-	[fileStream closed
-		ifTrue: [fileStream open].
-	fileStream setToEnd; nextPutAll: aString; cr]
-		ensure: [fileStream close]
+MTAnalysisFileLogger >> writeLineToFile: aString [
+
+	fileReference writeStreamDo: [ :stream |
+		stream
+			setToEnd;
+			nextPutAll: aString;
+			cr ]
 ]

--- a/src/MuTalk-Tests/MTAnalysisFileLoggerTest.class.st
+++ b/src/MuTalk-Tests/MTAnalysisFileLoggerTest.class.st
@@ -1,0 +1,23 @@
+Class {
+	#name : 'MTAnalysisFileLoggerTest',
+	#superclass : 'TestCase',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'tests' }
+MTAnalysisFileLoggerTest >> testLogFileExists [
+
+	| analysis logFileName logFile |
+	logFileName := 'logFileForTest.txt'.
+	logFile := logFileName asFileReference.
+	analysis := MTAnalysis new
+		            classesToMutate: { MTAuxiliarClassForMTAnalysis };
+		            testClasses: { MTAuxiliarClassForMTAnalysisTest };
+		            logger: (MTAnalysisFileLogger toFileNamed: logFileName).
+
+	analysis run.
+
+	self assert: logFile exists.
+	logFile delete
+]


### PR DESCRIPTION
Updated `MTAnalysisFileLogger` with new file managing system.
You can use it like that: 
```smalltalk
analysis := MTAnalysis new
	            classesToMutate: { UUID };
	            testClasses: { UUIDTest };
	            logger: (MTAnalysisFileLogger toFileNamed: 'log.txt').
analysis run
```