### PR TITLE
Add heatmap to MTMatrix

### DIFF
--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -52,6 +52,12 @@ MTTestCaseReference >> method [
 	^ class >> selector
 ]
 
+{ #category : 'printing' }
+MTTestCaseReference >> printOn: aStream [
+
+	aStream nextPutAll: (aStream print: self testCase)
+]
+
 { #category : 'evaluating' }
 MTTestCaseReference >> resources [
 	^self testCase resources

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -244,6 +244,9 @@ MTMatrix >> initializeHeatmap [
 	heatmap := RSHeatmap new.
 	heatmap labelShapeCell labelShape bold.
 	heatmap shape extent: 50 @ 20.
+	heatmap colorPalette: (NSScale linear range: {
+				 Color yellow.
+				 Color red }).
 	^ heatmap
 ]
 

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -120,6 +120,33 @@ MTMatrix >> classesToMutate: aClass [
 	classesToMutate := aClass
 ]
 
+{ #category : 'as yet unclassified' }
+MTMatrix >> dataForTests: testCollection andMutations: mutationCollection [
+
+	| totalNumberOfTests numberOfFailuresCollection killedCount |
+	totalNumberOfTests := testCollection size * mutationCollection size.
+	numberOfFailuresCollection := mutationCollection collect: [ :mutation |
+		                              ((self failuresFor: mutation) select: [
+			                               :testCase |
+			                               testCase testCaseClass
+			                               =
+			                               (testCollection at: 1) testCaseClass ])
+			                              size ].
+	killedCount := numberOfFailuresCollection fold: [ :num1 :num2 |
+		               num1 + num2 ].
+	^ (killedCount / totalNumberOfTests * 100) asInteger
+]
+
+{ #category : 'as yet unclassified' }
+MTMatrix >> dataMatrixForTests: testDictionary andMutations: mutationDictionary [
+
+	^ (mutationDictionary collect: [ :mutationCollection |
+		   (testDictionary collect: [ :testCollection |
+			    self
+				    dataForTests: testCollection
+				    andMutations: mutationCollection ]) asArray ]) asArray
+]
+
 { #category : 'accessing' }
 MTMatrix >> equivalentMutants [
 
@@ -156,6 +183,34 @@ MTMatrix >> failuresFor: aMutant [
 
 	^ (self evaluationResultFor: aMutant) defects asOrderedCollection collect: [ :each |
 		  MTTestCaseReference for: each selector in: each class ]
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmap [
+
+	| heatmap mutationDictionary testDictionary |
+	mutationDictionary := mutations groupedBy: [ :mutation |
+		                      mutation operator species ].
+	testDictionary := testCases groupedBy: #testCaseClass.
+
+	heatmap := RSHeatmap new.
+	heatmap colorPalette: (NSScale linear range: {
+				 Color gray.
+				 Color purple muchDarker }).
+	heatmap labelShapeCell labelShape
+		border: (RSBorder new
+				 color: Color black;
+				 width: 0.2);
+		color: Color white.
+	heatmap shape extent: 50 @ 20.
+
+	heatmap objectsX: testClasses.
+	heatmap objectsY: mutationDictionary keys.
+	heatmap dataMatrix: (self
+			 dataMatrixForTests: testDictionary
+			 andMutations: mutationDictionary).
+
+	heatmap open
 ]
 
 { #category : 'rendering' }

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -120,24 +120,24 @@ MTMatrix >> classesToMutate: aClass [
 	classesToMutate := aClass
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'computing' }
 MTMatrix >> dataForTests: testCollection andMutations: mutationCollection [
 
 	| totalNumberOfTests numberOfFailuresCollection killedCount |
 	totalNumberOfTests := testCollection size * mutationCollection size.
 	numberOfFailuresCollection := mutationCollection collect: [ :mutation |
-		                              ((self failuresFor: mutation) select: [
-			                               :testCase |
-			                               testCase testCaseClass
-			                               =
-			                               (testCollection at: 1) testCaseClass ])
-			                              size ].
+		                              | testClass |
+		                              testClass := testCollection atRandom
+			                                           testCaseClass.
+		                              (self
+			                               failuresFor: mutation
+			                               andTestClass: testClass) size ].
 	killedCount := numberOfFailuresCollection fold: [ :num1 :num2 |
 		               num1 + num2 ].
 	^ (killedCount / totalNumberOfTests * 100) asInteger
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'computing' }
 MTMatrix >> dataMatrixForTests: testDictionary andMutations: mutationDictionary [
 
 	^ (mutationDictionary collect: [ :mutationCollection |
@@ -183,6 +183,13 @@ MTMatrix >> failuresFor: aMutant [
 
 	^ (self evaluationResultFor: aMutant) defects asOrderedCollection collect: [ :each |
 		  MTTestCaseReference for: each selector in: each class ]
+]
+
+{ #category : 'computing' }
+MTMatrix >> failuresFor: aMutation andTestClass: aTestClass [
+
+	^ (self failuresFor: aMutation) select: [ :testCase |
+		  testCase testCaseClass = aTestClass ]
 ]
 
 { #category : 'rendering' }

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -232,9 +232,6 @@ MTMatrix >> initializeHeatmap [
 
 	| heatmap |
 	heatmap := RSHeatmap new.
-	heatmap colorPalette: (NSScale linear range: {
-				 Color red.
-				 Color red muchLighter }).
 	heatmap labelShapeCell labelShape bold.
 	heatmap shape extent: 50 @ 20.
 	^ heatmap

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -193,16 +193,7 @@ MTMatrix >> generateHeatmap [
 		                      mutation operator species ].
 	testDictionary := testCases groupedBy: #testCaseClass.
 
-	heatmap := RSHeatmap new.
-	heatmap colorPalette: (NSScale linear range: {
-				 Color gray.
-				 Color purple muchDarker }).
-	heatmap labelShapeCell labelShape
-		border: (RSBorder new
-				 color: Color black;
-				 width: 0.2);
-		color: Color white.
-	heatmap shape extent: 50 @ 20.
+	heatmap := self initializeHeatmap.
 
 	heatmap objectsX: testClasses.
 	heatmap objectsY: mutationDictionary keys.
@@ -234,6 +225,19 @@ MTMatrix >> includedMutants [
 	self addMutantSetsIn: includedMutants using: #includes.
 
 	^ includedMutants
+]
+
+{ #category : 'initialization' }
+MTMatrix >> initializeHeatmap [
+
+	| heatmap |
+	heatmap := RSHeatmap new.
+	heatmap colorPalette: (NSScale linear range: {
+				 Color red.
+				 Color red muchLighter }).
+	heatmap labelShapeCell labelShape bold.
+	heatmap shape extent: 50 @ 20.
+	^ heatmap
 ]
 
 { #category : 'comparing' }

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -123,28 +123,31 @@ MTMatrix >> classesToMutate: aClass [
 { #category : 'computing' }
 MTMatrix >> dataForTests: testCollection andMutations: mutationCollection [
 
-	| totalNumberOfTests numberOfFailuresCollection killedCount |
-	totalNumberOfTests := testCollection size * mutationCollection size.
+	| totalNumberOfTestsExecuted numberOfFailuresCollection totalNumberOfFailures |
+	totalNumberOfTestsExecuted := testCollection size
+	                              * mutationCollection size.
 	numberOfFailuresCollection := mutationCollection collect: [ :mutation |
 		                              | testClass |
+		                              "We know that all tests from testCollection are from the same class"
 		                              testClass := testCollection atRandom
 			                                           testCaseClass.
 		                              (self
 			                               failuresFor: mutation
 			                               andTestClass: testClass) size ].
-	killedCount := numberOfFailuresCollection fold: [ :num1 :num2 |
-		               num1 + num2 ].
-	^ (killedCount / totalNumberOfTests * 100) asInteger
+	totalNumberOfFailures := numberOfFailuresCollection fold: [ :num1 :num2 |
+		                         num1 + num2 ].
+	^ (totalNumberOfFailures / totalNumberOfTestsExecuted * 100)
+		  asInteger
 ]
 
 { #category : 'computing' }
 MTMatrix >> dataMatrixForTests: testDictionary andMutations: mutationDictionary [
 
-	^ (mutationDictionary collect: [ :mutationCollection |
-		   (testDictionary collect: [ :testCollection |
-			    self
-				    dataForTests: testCollection
-				    andMutations: mutationCollection ]) asArray ]) asArray
+	^ mutationDictionary values collect: [ :mutationCollection |
+		  testDictionary values collect: [ :testCollection |
+			  self
+				  dataForTests: testCollection
+				  andMutations: mutationCollection ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
You can now generate a heatmap for `MTMatrix`.
It groups the mutations by operator and the tests by class, and represents the percentage of the mutations from a given operator that are killed by the tests from a given class.
```smalltalk
matrix := MTMatrix forClasses: { UUID } andTests: {
		          UUIDTest.
		          UUIDPrimitivesTest }.
matrix build.
matrix generateHeatmap
```
![image](https://github.com/pharo-contributions/mutalk/assets/124769707/ad07a031-bbfd-4d49-a7f6-718899f1d407)
