### PR TITLE
Mutalk handles parametrized tests correctly

### DIFF
--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -697,8 +697,8 @@ MTAnalysis >> testCasesFrom: aClassCollection [
 { #category : 'tests' }
 MTAnalysis >> testCasesReferencesFrom: testClass [
 
-	^ testClass allTestSelectors collect: [ :each |
-		  MTTestCaseReference for: each in: testClass ]
+	^ testClass buildSuite tests collect: [ :each |
+		  MTTestCaseReference for: each ]
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -21,7 +21,8 @@ MTTestCaseReference >> = anObject [
 
 	self == anObject ifTrue: [ ^ true ].
 	anObject species = self class ifFalse: [ ^ false ].
-	^ self testCase = anObject testCase
+	self testCaseClass = anObject testCaseClass ifFalse: [ ^ false ].
+	^ self selector = anObject selector
 ]
 
 { #category : 'comparing' }

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -2,8 +2,7 @@ Class {
 	#name : 'MTTestCaseReference',
 	#superclass : 'Object',
 	#instVars : [
-		'class',
-		'selector',
+		'testCase',
 		'lastTimeToRun'
 	],
 	#category : 'MuTalk-Model-Core',
@@ -12,13 +11,9 @@ Class {
 }
 
 { #category : 'instance creation' }
-MTTestCaseReference class >> for: aSelector in: aClass [ 
-	^self new initializeFor: aSelector in: aClass
-]
+MTTestCaseReference class >> for: aTestCase [
 
-{ #category : 'instance creation' }
-MTTestCaseReference class >> forTestCase: aTestCase [ 
-	^self for: aTestCase selector in: aTestCase class
+	^ self new initializeFor: aTestCase
 ]
 
 { #category : 'comparing' }
@@ -26,42 +21,43 @@ MTTestCaseReference >> = anObject [
 
 	self == anObject ifTrue: [ ^ true ].
 	anObject species = self class ifFalse: [ ^ false ].
-	self testCaseClass = anObject testCaseClass ifFalse: [ ^ false ].
-	^ self selector = anObject selector
+	^ self testCase = anObject testCase
 ]
 
 { #category : 'comparing' }
 MTTestCaseReference >> hash [
 
-	^ selector hash + class hash
+	^ testCase selector hash + testCase class hash
 ]
 
 { #category : 'initialize' }
-MTTestCaseReference >> initializeFor: aSelector in: aClass [
-	class := aClass.
-	selector := aSelector.
+MTTestCaseReference >> initializeFor: aTestCase [
+
+	testCase := aTestCase
 ]
 
 { #category : 'accessing' }
 MTTestCaseReference >> lastTimeToRun [
+
 	^ lastTimeToRun
 ]
 
 { #category : 'accessing' }
 MTTestCaseReference >> method [
-	
-	^ class >> selector
+
+	^ testCase class >> testCase selector
 ]
 
 { #category : 'printing' }
 MTTestCaseReference >> printOn: aStream [
 
-	aStream nextPutAll: (aStream print: self testCase)
+	aStream nextPutAll: (aStream print: testCase)
 ]
 
 { #category : 'evaluating' }
 MTTestCaseReference >> resources [
-	^self testCase resources
+
+	^ testCase resources
 ]
 
 { #category : 'evaluating' }
@@ -74,15 +70,18 @@ MTTestCaseReference >> run [
 
 { #category : 'evaluating' }
 MTTestCaseReference >> run: aTestResult [
-	^self testCase run: aTestResult
+
+	^ testCase run: aTestResult
 ]
 
 { #category : 'evaluating' }
 MTTestCaseReference >> runChecked [
-	| result |	
+
+	| result |
 	result := self runUnchecked.
-	(result unexpectedFailureCount > 0 or: [ result unexpectedErrorCount > 0 ])
-		ifTrue: [ MTTestsWithErrorsException signal ].
+	(result unexpectedFailureCount > 0 or: [
+		 result unexpectedErrorCount > 0 ]) ifTrue: [
+		MTTestsWithErrorsException signal ].
 	^ result
 ]
 
@@ -90,23 +89,24 @@ MTTestCaseReference >> runChecked [
 MTTestCaseReference >> runUnchecked [
 
 	| result |
-	lastTimeToRun := [ result := self testCase run ] timeToRun.
+	lastTimeToRun := [ result := testCase run ] timeToRun.
 	^ result
 ]
 
 { #category : 'accessing' }
 MTTestCaseReference >> selector [
 
-	^ selector
+	^ testCase selector
 ]
 
 { #category : 'evaluating' }
 MTTestCaseReference >> testCase [
-	^class selector: selector.
+
+	^ testCase class selector: testCase selector
 ]
 
 { #category : 'accessing' }
 MTTestCaseReference >> testCaseClass [
 
-	^ class
+	^ testCase class
 ]

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -103,7 +103,7 @@ MTTestCaseReference >> selector [
 { #category : 'evaluating' }
 MTTestCaseReference >> testCase [
 
-	^ testCase class selector: testCase selector
+	^ testCase
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Model/MTTestCasesSelectionStrategy.class.st
+++ b/src/MuTalk-Model/MTTestCasesSelectionStrategy.class.st
@@ -25,5 +25,5 @@ MTTestCasesSelectionStrategy >> testCasesFromReferencies: aTestReferenceCollecti
 		             testReference testCase ].
 	selectedTestCases := self testCasesFor: testCases.
 	^ selectedTestCases collect: [ :testCase |
-		  MTTestCaseReference forTestCase: testCase ]
+		  MTTestCaseReference for: testCase ]
 ]

--- a/src/MuTalk-TestResources/MTAuxiliarParametrizedTestClass.class.st
+++ b/src/MuTalk-TestResources/MTAuxiliarParametrizedTestClass.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : 'MTAuxiliarParametrizedTestClass',
+	#superclass : 'ParametrizedTestCase',
+	#instVars : [
+		'number'
+	],
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}
+
+{ #category : 'building suites' }
+MTAuxiliarParametrizedTestClass class >> testParameters [
+
+	^ ParametrizedTestMatrix new
+		  forSelector: #number addOptions: { 1. 2. 3 };
+		  yourself
+]
+
+{ #category : 'accessing' }
+MTAuxiliarParametrizedTestClass >> number: aNumber [
+
+	number := aNumber
+]
+
+{ #category : 'testing' }
+MTAuxiliarParametrizedTestClass >> testAddZero [
+
+	self assert: number + 0 equals: number
+]

--- a/src/MuTalk-Tests/MTAnalysisTest.class.st
+++ b/src/MuTalk-Tests/MTAnalysisTest.class.st
@@ -60,6 +60,17 @@ MTAnalysisTest >> selectForRejectReplacementMutation [
 ]
 
 { #category : 'tests' }
+MTAnalysisTest >> testCorrectNumberOfTestCasesWithParametrizedTestCase [
+
+	| analysis |
+	analysis := MTAnalysis new
+		            testClasses: { MTAuxiliarParametrizedTestClass };
+		            classesToMutate: {  }.
+
+	self assert: analysis testCases size equals: 3
+]
+
+{ #category : 'tests' }
 MTAnalysisTest >> testDefaultParameters [
 
 	| analysis |

--- a/src/MuTalk-Tests/MTMethodMutationTest.class.st
+++ b/src/MuTalk-Tests/MTMethodMutationTest.class.st
@@ -68,12 +68,13 @@ MTMethodMutationTest >> testMutatedNodeBugFix [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationInfiniteLoop [
 
-	| compiledMethod operator modifiedSource methodMutation res |
+	| compiledMethod operator modifiedSource methodMutation res testCase |
 	"This test will execute another test that will time out.
 	So this test will need a higher time limit"
 	self timeLimit: self defaultTimeLimit + (Duration milliSeconds: 10).
 
 	compiledMethod := MTFakeInfiniteLoopForTest >> #iterativeFactorial:.
+	testCase := MTFakeInfiniteLoopsTest selector: #testIterativeFactorial.
 	operator := MTReplaceLessOrEqualWithTrueOperator new.
 
 	modifiedSource := operator
@@ -85,9 +86,8 @@ MTMethodMutationTest >> testMutationInfiniteLoop [
 		                  nodeNumber: 1
 		                  ofClass: MTFakeInfiniteLoopForTest.
 
-	methodMutation testCaseReferences: { (MTTestCaseReference
-			 for: #testIterativeFactorial
-			 in: MTFakeInfiniteLoopsTest) }.
+	methodMutation testCaseReferences:
+		{ (MTTestCaseReference for: testCase) }.
 
 	res := methodMutation runMutantStoppingOnError: true in: nil.
 
@@ -97,12 +97,13 @@ MTMethodMutationTest >> testMutationInfiniteLoop [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationInfiniteRecursion [
 
-	| compiledMethod operator modifiedSource methodMutation res |
+	| compiledMethod operator modifiedSource methodMutation res testCase |
 	"This test will execute another test that will time out.
 	So this test will need a higher time limit"
 	self timeLimit: self defaultTimeLimit + (Duration milliSeconds: 10).
 
 	compiledMethod := MTFakeInfiniteLoopForTest >> #recursiveFactorial:.
+	testCase := MTFakeInfiniteLoopsTest selector: #testRecursiveFactorial.
 	operator := MTReplaceIfTrueReceiverWithFalseOperator new.
 
 	modifiedSource := operator
@@ -114,9 +115,8 @@ MTMethodMutationTest >> testMutationInfiniteRecursion [
 		                  nodeNumber: 1
 		                  ofClass: MTFakeInfiniteLoopForTest.
 
-	methodMutation testCaseReferences: { (MTTestCaseReference
-			 for: #testRecursiveFactorial
-			 in: MTFakeInfiniteLoopsTest) }.
+	methodMutation testCaseReferences:
+		{ (MTTestCaseReference for: testCase) }.
 
 	res := methodMutation runMutantStoppingOnError: true in: nil.
 
@@ -126,7 +126,8 @@ MTMethodMutationTest >> testMutationInfiniteRecursion [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationNotInstalling [
 
-	| methodMutation res mutantEvaluation |
+	| methodMutation res mutantEvaluation testCase |
+	testCase := MTFakeInfiniteLoopsTest selector: #testRecursiveFactorial.
 	methodMutation := MTFailedInstallMethodMutation
 		                  for:
 		                  MTFakeInfiniteLoopForTest >> #iterativeFactorial:
@@ -137,9 +138,7 @@ MTMethodMutationTest >> testMutationNotInstalling [
 
 	mutantEvaluation := MTMutantEvaluation
 		                    for: methodMutation
-		                    using: { (MTTestCaseReference
-				                     for: #testRecursiveFactorial
-				                     in: MTFakeInfiniteLoopsTest) }
+		                    using: { (MTTestCaseReference for: testCase) }
 		                    following:
 		                    MTAllTestsMethodsRunningTestSelectionStrategy
 			                    new
@@ -152,7 +151,8 @@ MTMethodMutationTest >> testMutationNotInstalling [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationNotRunning [
 
-	| methodMutation res mutantEvaluation |
+	| methodMutation res mutantEvaluation testCase |
+	testCase := MTFakeInfiniteLoopsTest selector: #testRecursiveFactorial.
 	methodMutation := MTFailedRunMethodMutation
 		                  for:
 		                  MTFakeInfiniteLoopForTest >> #iterativeFactorial:
@@ -163,9 +163,7 @@ MTMethodMutationTest >> testMutationNotRunning [
 
 	mutantEvaluation := MTMutantEvaluation
 		                    for: methodMutation
-		                    using: { (MTTestCaseReference
-				                     for: #testRecursiveFactorial
-				                     in: MTFakeInfiniteLoopsTest) }
+		                    using: { (MTTestCaseReference for: testCase) }
 		                    following:
 		                    MTAllTestsMethodsRunningTestSelectionStrategy
 			                    new
@@ -178,7 +176,8 @@ MTMethodMutationTest >> testMutationNotRunning [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationNotUninstalling [
 
-	| methodMutation res mutantEvaluation |
+	| methodMutation res mutantEvaluation testCase |
+	testCase := MTFakeInfiniteLoopsTest selector: #testRecursiveFactorial.
 	methodMutation := MTFailedUninstallMethodMutation
 		                  for:
 		                  MTFakeInfiniteLoopForTest >> #iterativeFactorial:
@@ -189,9 +188,7 @@ MTMethodMutationTest >> testMutationNotUninstalling [
 
 	mutantEvaluation := MTMutantEvaluation
 		                    for: methodMutation
-		                    using: { (MTTestCaseReference
-				                     for: #testRecursiveFactorial
-				                     in: MTFakeInfiniteLoopsTest) }
+		                    using: { (MTTestCaseReference for: testCase) }
 		                    following:
 		                    MTAllTestsMethodsRunningTestSelectionStrategy
 			                    new
@@ -204,9 +201,10 @@ MTMethodMutationTest >> testMutationNotUninstalling [
 { #category : 'tests' }
 MTMethodMutationTest >> testMutationRun [
 
-	| compiledMethod operator modifiedSource methodMutation res |
+	| compiledMethod operator modifiedSource methodMutation res testCase |
 	compiledMethod := MTAuxiliarClassForMTAnalysis
 	                  >> #methodWithOnePlusSender.
+	testCase := self class selector: #simpleTestCaseRessource.
 	operator := MTReplacePlusWithMinusMutantOperator new.
 	modifiedSource := operator
 		                  modifiedSourceFor: compiledMethod
@@ -217,7 +215,7 @@ MTMethodMutationTest >> testMutationRun [
 		                  nodeNumber: 1
 		                  ofClass: MTAuxiliarClassForMTAnalysis.
 	methodMutation testCaseReferences:
-		{ (MTTestCaseReference for: #simpleTestCaseRessource in: self class) }.
+		{ (MTTestCaseReference for: testCase) }.
 	res := methodMutation runMutantStoppingOnError: true in: nil.
 
 	self assert: res runCount equals: 1

--- a/src/MuTalk-Tests/MTTestCaseReferenceTest.class.st
+++ b/src/MuTalk-Tests/MTTestCaseReferenceTest.class.st
@@ -21,5 +21,5 @@ MTTestCaseReferenceTest >> testATestReferenceResult [
 { #category : 'resources' }
 MTTestCaseReferenceTest >> testReferenceForTest1 [
 
-	^ MTTestCaseReference for: #test1 in: self class
+	^ MTTestCaseReference for: (self class selector: #test1)
 ]

--- a/src/MuTalk-Tests/MTTestCasesSelectionStrategyTest.class.st
+++ b/src/MuTalk-Tests/MTTestCasesSelectionStrategyTest.class.st
@@ -19,7 +19,8 @@ MTTestCasesSelectionStrategyTest >> allTestsFromPackage [
 			   MTAuxiliarTestClassForContinuingTestsExecutionAfterFirstFail.
 			   MTAuxiliarClassForTimeTestFilterTest.
 			   MTAuxiliarTestClassForBlockTestFilter.
-			   MTAuxiliarTestClassForPragmaTestFilter })
+			   MTAuxiliarTestClassForPragmaTestFilter.
+			   MTAuxiliarParametrizedTestClass })
 		  inject: OrderedCollection new
 		  into: [ :tests :testClass |
 			  tests addAll: testClass suite tests.

--- a/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
@@ -17,10 +17,10 @@ MTTimeTestFilterTest >> runAnalysisForTimeCondition: aDuration [
 { #category : 'tests' }
 MTTimeTestFilterTest >> testWith10MillisecondsCondition [
 
-	| testCaseReference result |
-	testCaseReference := MTTestCaseReference
-		                     for: #test10Milliseconds
-		                     in: MTAuxiliarClassForTimeTestFilterTest.
+	| testCaseReference result testCase |
+	testCase := MTAuxiliarClassForTimeTestFilterTest selector:
+		            #test10Milliseconds.
+	testCaseReference := MTTestCaseReference for: testCase.
 	self runAnalysisForTimeCondition:
 		(self timeToRunFor: testCaseReference) * 10.
 	result := analysis generalResult particularResults at: 1.
@@ -34,10 +34,10 @@ MTTimeTestFilterTest >> testWith10MillisecondsCondition [
 { #category : 'tests' }
 MTTimeTestFilterTest >> testWith1SecondCondition [
 
-	| testCaseReference |
-	testCaseReference := MTTestCaseReference
-		                     for: #test1Second
-		                     in: MTAuxiliarClassForTimeTestFilterTest.
+	| testCaseReference testCase |
+	testCase := MTAuxiliarClassForTimeTestFilterTest selector:
+		            #test1Second.
+	testCaseReference := MTTestCaseReference for: testCase.
 	self runAnalysisForTimeCondition:
 		(self timeToRunFor: testCaseReference) * 10.
 

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -184,8 +184,8 @@ MTMatrix >> failingTestsFor: aMutation [
 { #category : 'computing' }
 MTMatrix >> failuresFor: aMutant [
 
-	^ (self evaluationResultFor: aMutant) defects asOrderedCollection collect: [ :each |
-		  MTTestCaseReference for: each selector in: each class ]
+	^ (self evaluationResultFor: aMutant) defects asOrderedCollection
+		  collect: [ :each | MTTestCaseReference for: each ]
 ]
 
 { #category : 'computing' }


### PR DESCRIPTION
Fixes #88 
Now `MTAnalysis` retrieves correctly all tests cases from parametrized tests.
I also refactored a bit `MTTestCaseReference` so that it now has the test case as instance variable rather than the class and the selector.