### PR TITLE
Red test filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,19 @@ Mutation Testing in Smalltalk
 This project was originally developed at the University of Buenos Aires (Argentina) by Nicolás Chillo, Gabriel Brunstein and others in times of Pharo 1.1.
 
 ## How to load
+
+* Latest release:
 ```smalltalk
 Metacello new
   baseline: 'MuTalk';
   repository: 'github://pharo-contributions/mutalk:v2.1.0/src';
+  load.
+```
+* Full version:
+```smalltalk
+Metacello new
+  baseline: 'MuTalk';
+  repository: 'github://pharo-contributions/mutalk/src';
   load.
 ```
 

--- a/src/MuTalk-CI/MTCoveragePropagationPreparation.class.st
+++ b/src/MuTalk-CI/MTCoveragePropagationPreparation.class.st
@@ -175,7 +175,7 @@ MTCoveragePropagationPreparation >> runTestCase: testCaseReference [
 	| results |
 	counter := 1.
 	results := TestAsserter classForTestResult new.
-	results addAllResults: testCaseReference runUnchecked.
+	results addAllResults: testCaseReference run.
 	^ results
 ]
 

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -121,7 +121,9 @@ MTAnalysis >> generateMutations [
 { #category : 'running' }
 MTAnalysis >> generateResults [
 
+	| filteredTests |
 	mutantResults := OrderedCollection new.
+	filteredTests := testFilter filterTests: testCases.
 
 	mutations do: [ :aMutation |
 		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
@@ -129,7 +131,7 @@ MTAnalysis >> generateResults [
 		logger logStartEvaluating: aMutation.
 		mutantResults add: ((MTMutantEvaluation
 				  for: aMutation
-				  using: testCases
+				  using: filteredTests
 				  following: testSelectionStrategy
 				  andConsidering: self coverageAnalysisResult)
 				 valueStoppingOnError: stopOnErrorOrFail) ].

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -555,14 +555,11 @@ MTAnalysis >> initialTestRun [
 	| results |
 	results := testCases collect: [ :aTestCase | aTestCase run ].
 
-	testFilter species = MTRedTestFilter
-		ifTrue: [
-			"If there are failing tests, they will be filtered anyway"
-			testCases := testFilter filterTests: testCases withResults: results ]
-		ifFalse: [
-			(self resultsContainUnexpectedFailuresOrErrorsFor: results)
-				ifTrue: [ ^ MTTestsWithErrorsException signal ]
-				ifFalse: [ testCases := testFilter filterTests: testCases ] ]
+	(testFilter species ~= MTRedTestFilter and: [
+		 self resultsContainUnexpectedFailuresOrErrorsFor: results ])
+		ifTrue: [ MTTestsWithErrorsException signal ].
+
+	testCases := testFilter filterTests: testCases
 ]
 
 { #category : 'initialization' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -533,9 +533,7 @@ MTAnalysis >> generateMutations [
 { #category : 'running' }
 MTAnalysis >> generateResults [
 
-	| tests |
 	mutantResults := OrderedCollection new.
-	tests := testFilter filterTests: testCases.
 
 	mutations do: [ :aMutation |
 		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
@@ -543,7 +541,7 @@ MTAnalysis >> generateResults [
 		logger logStartEvaluating: aMutation.
 		mutantResults add: ((MTMutantEvaluation
 				  for: aMutation
-				  using: tests
+				  using: testCases
 				  following: testSelectionStrategy
 				  andConsidering: self coverageAnalysisResult)
 				 valueStoppingOnError: stopOnErrorOrFail) ].
@@ -552,10 +550,19 @@ MTAnalysis >> generateResults [
 
 { #category : 'running' }
 MTAnalysis >> initialTestRun [
-	"Do an initial run of the tests to check that they are all green.
-	Only green tests count for the mutation testing analysis"
 
-	testCases do: [ :aTestCase | aTestCase run ]
+	| results |
+	results := testCases collect: [ :aTestCase | aTestCase run ].
+
+	testFilter species = MTRedTestFilter
+		ifTrue: [
+		testCases := testFilter filterTests: testCases withResults: results ]
+		ifFalse: [
+			(results anySatisfy: [ :result |
+				 result unexpectedFailureCount > 0 or: [
+					 result unexpectedErrorCount > 0 ] ])
+				ifTrue: [ ^ MTTestsWithErrorsException signal ]
+				ifFalse: [ testCases := testFilter filterTests: testCases ] ]
 ]
 
 { #category : 'initialization' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -555,7 +555,7 @@ MTAnalysis >> initialTestRun [
 	"Do an initial run of the tests to check that they are all green.
 	Only green tests count for the mutation testing analysis"
 
-	testCases do: [ :aTestCase | aTestCase runChecked ]
+	testCases do: [ :aTestCase | aTestCase run ]
 ]
 
 { #category : 'initialization' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -554,11 +554,7 @@ MTAnalysis >> initialTestRun [
 
 	| results |
 	results := testCases collect: [ :aTestCase | aTestCase run ].
-
-	(testFilter species ~= MTRedTestFilter and: [
-		 self resultsContainUnexpectedFailuresOrErrorsFor: results ])
-		ifTrue: [ MTTestsWithErrorsException signal ].
-
+	testFilter validateFailuresIn: results.
 	testCases := testFilter filterTests: testCases
 ]
 
@@ -638,14 +634,6 @@ MTAnalysis >> operators [
 MTAnalysis >> operators: anObject [
 
 	operators := anObject
-]
-
-{ #category : 'testing' }
-MTAnalysis >> resultsContainUnexpectedFailuresOrErrorsFor: results [
-
-	^ results anySatisfy: [ :result |
-		  result unexpectedFailureCount > 0 or: [
-			  result unexpectedErrorCount > 0 ] ]
 ]
 
 { #category : 'running' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -124,9 +124,7 @@ MTAnalysis >> generateMutations [
 { #category : 'running' }
 MTAnalysis >> generateResults [
 
-	| filteredTests |
 	mutantResults := OrderedCollection new.
-	filteredTests := testFilter filterTests: testCases.
 
 	mutations do: [ :aMutation |
 		(budget exceedsBudgetOn: mutantResults fromTotalMutations: mutations)
@@ -134,7 +132,7 @@ MTAnalysis >> generateResults [
 		logger logStartEvaluating: aMutation.
 		mutantResults add: ((MTMutantEvaluation
 				  for: aMutation
-				  using: filteredTests
+				  using: testCases
 				  following: testSelectionStrategy
 				  andConsidering: self coverageAnalysisResult)
 				 valueStoppingOnError: stopOnErrorOrFail) ].

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -550,17 +550,17 @@ MTAnalysis >> generateResults [
 
 { #category : 'running' }
 MTAnalysis >> initialTestRun [
+	"Runs all tests once and filters them"
 
 	| results |
 	results := testCases collect: [ :aTestCase | aTestCase run ].
 
 	testFilter species = MTRedTestFilter
 		ifTrue: [
-		testCases := testFilter filterTests: testCases withResults: results ]
+			"If there are failing tests, they will be filtered anyway"
+			testCases := testFilter filterTests: testCases withResults: results ]
 		ifFalse: [
-			(results anySatisfy: [ :result |
-				 result unexpectedFailureCount > 0 or: [
-					 result unexpectedErrorCount > 0 ] ])
+			(self resultsContainUnexpectedFailuresOrErrorsFor: results)
 				ifTrue: [ ^ MTTestsWithErrorsException signal ]
 				ifFalse: [ testCases := testFilter filterTests: testCases ] ]
 ]
@@ -641,6 +641,14 @@ MTAnalysis >> operators [
 MTAnalysis >> operators: anObject [
 
 	operators := anObject
+]
+
+{ #category : 'as yet unclassified' }
+MTAnalysis >> resultsContainUnexpectedFailuresOrErrorsFor: results [
+
+	^ results anySatisfy: [ :result |
+		  result unexpectedFailureCount > 0 or: [
+			  result unexpectedErrorCount > 0 ] ]
 ]
 
 { #category : 'running' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -469,7 +469,7 @@ MTAnalysis >> defaultBudget [
 	^ MTFreeBudget new
 ]
 
-{ #category : 'defaults' }
+{ #category : 'accessing - defaults' }
 MTAnalysis >> defaultLogger [
 
 	^ MTNullAnalysisLogger new
@@ -640,7 +640,7 @@ MTAnalysis >> operators: anObject [
 	operators := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'testing' }
 MTAnalysis >> resultsContainUnexpectedFailuresOrErrorsFor: results [
 
 	^ results anySatisfy: [ :result |

--- a/src/MuTalk-Model/MTRedTestFilter.class.st
+++ b/src/MuTalk-Model/MTRedTestFilter.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : 'MTRedTestFilter',
+	#superclass : 'MTTestFilter',
+	#category : 'MuTalk-Model-Test filters',
+	#package : 'MuTalk-Model',
+	#tag : 'Test filters'
+}
+
+{ #category : 'enumerating' }
+MTRedTestFilter >> filterTests: aTestCaseCollection withResults: results [
+
+	| dictionary |
+	dictionary := Dictionary
+		              newFromKeys: aTestCaseCollection
+		              andValues: results.
+	^ dictionary keys select: [ :key |
+		  | result |
+		  result := dictionary at: key.
+		  result unexpectedFailureCount = 0 and: [
+			  result unexpectedErrorCount = 0 ] ]
+]

--- a/src/MuTalk-Model/MTRedTestFilter.class.st
+++ b/src/MuTalk-Model/MTRedTestFilter.class.st
@@ -7,15 +7,9 @@ Class {
 }
 
 { #category : 'enumerating' }
-MTRedTestFilter >> filterTests: aTestCaseCollection withResults: results [
+MTRedTestFilter >> filterTests: aTestCaseCollection [
 
-	| dictionary |
-	dictionary := Dictionary
-		              newFromKeys: aTestCaseCollection
-		              andValues: results.
-	^ dictionary keys select: [ :key |
-		  | result |
-		  result := dictionary at: key.
-		  result unexpectedFailureCount = 0 and: [
-			  result unexpectedErrorCount = 0 ] ]
+	^ aTestCaseCollection select: [ :testCase |
+		  testCase lastResult unexpectedFailureCount = 0 and: [
+			  testCase lastResult unexpectedErrorCount = 0 ] ]
 ]

--- a/src/MuTalk-Model/MTRedTestFilter.class.st
+++ b/src/MuTalk-Model/MTRedTestFilter.class.st
@@ -10,6 +10,6 @@ Class {
 MTRedTestFilter >> filterTests: aTestCaseCollection [
 
 	^ aTestCaseCollection select: [ :testCase |
-		  testCase lastResult unexpectedFailureCount = 0 and: [
+		  testCase lastResult failures isEmpty and: [
 			  testCase lastResult unexpectedErrorCount = 0 ] ]
 ]

--- a/src/MuTalk-Model/MTRedTestFilter.class.st
+++ b/src/MuTalk-Model/MTRedTestFilter.class.st
@@ -14,7 +14,8 @@ MTRedTestFilter >> filterTests: aTestCaseCollection [
 ]
 
 { #category : 'testing' }
-MTRedTestFilter >> resultsContainFailuresOrErrors: results [
+MTRedTestFilter >> unwantedFailuresOrErrorsIn: results [
+	"It is not a problem if there are unwanted failures or errors because they will be filtered out anyway"
 
 	^ false
 ]

--- a/src/MuTalk-Model/MTRedTestFilter.class.st
+++ b/src/MuTalk-Model/MTRedTestFilter.class.st
@@ -9,7 +9,12 @@ Class {
 { #category : 'enumerating' }
 MTRedTestFilter >> filterTests: aTestCaseCollection [
 
-	^ aTestCaseCollection select: [ :testCase |
-		  testCase lastResult failures isEmpty and: [
-			  testCase lastResult unexpectedErrorCount = 0 ] ]
+	^ aTestCaseCollection reject: [ :testCase |
+		  self failuresOrErrorsIn: testCase lastResult ]
+]
+
+{ #category : 'testing' }
+MTRedTestFilter >> resultsContainFailuresOrErrors: results [
+
+	^ false
 ]

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'class',
 		'selector',
-		'lastTimeToRun'
+		'lastTimeToRun',
+		'lastResult'
 	],
 	#category : 'MuTalk-Model-Core',
 	#package : 'MuTalk-Model',
@@ -43,6 +44,18 @@ MTTestCaseReference >> initializeFor: aSelector in: aClass [
 ]
 
 { #category : 'accessing' }
+MTTestCaseReference >> lastResult [
+
+	^ lastResult
+]
+
+{ #category : 'accessing' }
+MTTestCaseReference >> lastResult: anObject [
+
+	lastResult := anObject
+]
+
+{ #category : 'accessing' }
 MTTestCaseReference >> lastTimeToRun [
 	^ lastTimeToRun
 ]
@@ -67,9 +80,8 @@ MTTestCaseReference >> resources [
 { #category : 'evaluating' }
 MTTestCaseReference >> run [
 
-	| result |
-	lastTimeToRun := [ result := self testCase run ] timeToRun.
-	^ result
+	lastTimeToRun := [ lastResult := self testCase run ] timeToRun.
+	^ lastResult
 ]
 
 { #category : 'evaluating' }

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -66,10 +66,10 @@ MTTestCaseReference >> resources [
 
 { #category : 'evaluating' }
 MTTestCaseReference >> run [
-	"kept for retrocompatibility"
-	
-	self deprecated: 'Use #runChecked instead.' transformWith: '`@receiver run' -> '`@receiver runChecked'.
-	^ self runChecked
+
+	| result |
+	lastTimeToRun := [ result := self testCase run ] timeToRun.
+	^ result
 ]
 
 { #category : 'evaluating' }

--- a/src/MuTalk-Model/MTTestCaseReference.class.st
+++ b/src/MuTalk-Model/MTTestCaseReference.class.st
@@ -89,23 +89,6 @@ MTTestCaseReference >> run: aTestResult [
 	^self testCase run: aTestResult
 ]
 
-{ #category : 'evaluating' }
-MTTestCaseReference >> runChecked [
-	| result |	
-	result := self runUnchecked.
-	(result unexpectedFailureCount > 0 or: [ result unexpectedErrorCount > 0 ])
-		ifTrue: [ MTTestsWithErrorsException signal ].
-	^ result
-]
-
-{ #category : 'evaluating' }
-MTTestCaseReference >> runUnchecked [
-
-	| result |
-	lastTimeToRun := [ result := self testCase run ] timeToRun.
-	^ result
-]
-
 { #category : 'accessing' }
 MTTestCaseReference >> selector [
 

--- a/src/MuTalk-Model/MTTestFilter.class.st
+++ b/src/MuTalk-Model/MTTestFilter.class.st
@@ -42,7 +42,8 @@ MTTestFilter >> filterTests: aTestCaseCollection [
 ]
 
 { #category : 'testing' }
-MTTestFilter >> resultsContainFailuresOrErrors: results [
+MTTestFilter >> unwantedFailuresOrErrorsIn: results [
+	"Checks if the results contain failures or errors while they shouldn't"
 
 	^ results anySatisfy: [ :result | self failuresOrErrorsIn: result ]
 ]
@@ -50,6 +51,6 @@ MTTestFilter >> resultsContainFailuresOrErrors: results [
 { #category : 'checking' }
 MTTestFilter >> validateFailuresIn: results [
 
-	(self resultsContainFailuresOrErrors: results) ifTrue: [
+	(self unwantedFailuresOrErrorsIn: results) ifTrue: [
 		MTTestsWithErrorsException signal ]
 ]

--- a/src/MuTalk-Model/MTTestFilter.class.st
+++ b/src/MuTalk-Model/MTTestFilter.class.st
@@ -29,8 +29,27 @@ MTTestFilter >> condition: aCondition [
 	condition := aCondition
 ]
 
+{ #category : 'testing' }
+MTTestFilter >> failuresOrErrorsIn: result [
+
+	^ result failures isNotEmpty or: [ result unexpectedErrorCount > 0 ]
+]
+
 { #category : 'enumerating' }
 MTTestFilter >> filterTests: aTestCaseCollection [
 
 	^ self subclassResponsibility
+]
+
+{ #category : 'testing' }
+MTTestFilter >> resultsContainFailuresOrErrors: results [
+
+	^ results anySatisfy: [ :result | self failuresOrErrorsIn: result ]
+]
+
+{ #category : 'checking' }
+MTTestFilter >> validateFailuresIn: results [
+
+	(self resultsContainFailuresOrErrors: results) ifTrue: [
+		MTTestsWithErrorsException signal ]
 ]

--- a/src/MuTalk-TestResources/MTAuxiliarTestClassForRedTestFilter.class.st
+++ b/src/MuTalk-TestResources/MTAuxiliarTestClassForRedTestFilter.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : 'MTAuxiliarTestClassForRedTestFilter',
+	#superclass : 'TestCase',
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}
+
+{ #category : 'tests' }
+MTAuxiliarTestClassForRedTestFilter >> testWithError [
+
+	self error
+]
+
+{ #category : 'tests' }
+MTAuxiliarTestClassForRedTestFilter >> testWithoutError [
+
+	self assert: true
+]

--- a/src/MuTalk-Tests/MTRedTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTRedTestFilterTest.class.st
@@ -20,7 +20,6 @@ MTRedTestFilterTest >> testRedTestIsExcluded [
 	self runAnalysis.
 
 	self assert: analysis testCases size equals: 1.
-	self assert:
-		(analysis testCases includes: (MTTestCaseReference forTestCase:
+	self assert: (analysis testCases includes: (MTTestCaseReference for:
 				  (MTAuxiliarTestClassForRedTestFilter selector: #testWithoutError)))
 ]

--- a/src/MuTalk-Tests/MTRedTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTRedTestFilterTest.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'MTRedTestFilterTest',
+	#superclass : 'MTTestFilterTest',
+	#category : 'MuTalk-Tests',
+	#package : 'MuTalk-Tests'
+}
+
+{ #category : 'running' }
+MTRedTestFilterTest >> runAnalysis [
+
+	self
+		runAnalysisWithFilter: (MTRedTestFilter new)
+		on: { MTAuxiliarClassForTestFilter }
+		withTests: { MTAuxiliarTestClassForRedTestFilter }
+]
+
+{ #category : 'tests' }
+MTRedTestFilterTest >> testRedTestIsExcluded [
+
+	self runAnalysis.
+
+	self assert: analysis testCases size equals: 1.
+	self assert:
+		(analysis testCases includes: (MTTestCaseReference forTestCase:
+				  (MTAuxiliarTestClassForRedTestFilter selector: #testWithoutError)))
+]

--- a/src/MuTalk-Tests/MTTestCaseReferenceTest.class.st
+++ b/src/MuTalk-Tests/MTTestCaseReferenceTest.class.st
@@ -14,7 +14,7 @@ MTTestCaseReferenceTest >> test1 [
 MTTestCaseReferenceTest >> testATestReferenceResult [
 	| testReference |
 	testReference := self testReferenceForTest1.
-	self assert: testReference runUnchecked errors isEmpty.
+	self assert: testReference run errors isEmpty.
 	
 ]
 

--- a/src/MuTalk-Tests/MTTestCasesSelectionStrategyTest.class.st
+++ b/src/MuTalk-Tests/MTTestCasesSelectionStrategyTest.class.st
@@ -19,7 +19,8 @@ MTTestCasesSelectionStrategyTest >> allTestsFromPackage [
 			   MTAuxiliarTestClassForContinuingTestsExecutionAfterFirstFail.
 			   MTAuxiliarClassForTimeTestFilterTest.
 			   MTAuxiliarTestClassForBlockTestFilter.
-			   MTAuxiliarTestClassForPragmaTestFilter })
+			   MTAuxiliarTestClassForPragmaTestFilter.
+			   MTAuxiliarTestClassForRedTestFilter })
 		  inject: OrderedCollection new
 		  into: [ :tests :testClass |
 			  tests addAll: testClass suite tests.

--- a/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
+++ b/src/MuTalk-Tests/MTTimeTestFilterTest.class.st
@@ -49,6 +49,6 @@ MTTimeTestFilterTest >> testWith1SecondCondition [
 { #category : 'accessing' }
 MTTimeTestFilterTest >> timeToRunFor: aTestCaseReference [
 
-	aTestCaseReference runUnchecked.
+	aTestCaseReference run.
 	^ aTestCaseReference lastTimeToRun
 ]


### PR DESCRIPTION
Fixes #28

Added `MTRedTestFilter`, a test filter that allows to run the analysis even if there are failing tests during the initial test run.

Refactored by the way:
* how the analysis apply test filters
* `MTTestCaseReference` to include the last result as instance variable and the `#run` methods by moving the ` MTTestsWithErrorsException` (when there are failing tests in the initial test run) management in `MTAnalysis`