### PR TITLE
Analysis uses methods instead of classes & extension methods are ignored if not from package

### DIFF
--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -14,9 +14,10 @@ BaselineOfMuTalk >> baseline: spec [
 		   package: 'TestCoverage';
 			package: 'MuTalk-Model' with: [ spec requires: #( 'TestCoverage' ) ];
 			package: 'MuTalk-TestResources' with: [ spec requires: #( 'MuTalk-Model' ) ];
+			package: 'MuTalk-TestResourcesForExtensionMethods' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
 			package: 'MuTalk-CI' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-CI-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-CI' ) ];
-			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
+			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods ') ];
 			package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ];
 			package: 'MuTalk-Utilities' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-Utilities-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ].
@@ -24,6 +25,6 @@ BaselineOfMuTalk >> baseline: spec [
 		spec
 			group: 'default'
 			with:
-				#( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-Tests'
+				#( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods' 'MuTalk-Tests'
 				   'MuTalk-CI' 'MuTalk-CI-Tests' 'MuTalk-SpecUI' 'MuTalk-Utilities' 'MuTalk-Utilities-Tests' ) ]
 ]

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -17,7 +17,7 @@ BaselineOfMuTalk >> baseline: spec [
 			package: 'MuTalk-TestResourcesForExtensionMethods' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
 			package: 'MuTalk-CI' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-CI-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-CI' ) ];
-			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods ') ];
+			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods') ];
 			package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ];
 			package: 'MuTalk-Utilities' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-Utilities-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ].

--- a/src/MuTalk-Model/MTAllMutantGenerationStrategy.class.st
+++ b/src/MuTalk-Model/MTAllMutantGenerationStrategy.class.st
@@ -7,20 +7,7 @@ Class {
 }
 
 { #category : 'generating' }
-MTAllMutantGenerationStrategy >> classesAndMetaclassesFrom: modelClasses [ 
-	^ modelClasses
-		inject: OrderedCollection new
-		into: [:classes :aClass | 
-			classes add: aClass;
-				 add: aClass class.
-			classes]
-]
+MTAllMutantGenerationStrategy >> methodsToMutateFrom: aMutationTestingAnalysis [
 
-{ #category : 'generating' }
-MTAllMutantGenerationStrategy >> methodsToMutateFrom: aMutationTestingAnalysis [ 
-	^ (self classesAndMetaclassesFrom: aMutationTestingAnalysis modelClasses)
-		inject: OrderedCollection new
-		into: [:methods :aClass | 
-			methods addAll: aClass methods.
-			methods]
+	^ aMutationTestingAnalysis methodsToMutate
 ]

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -38,7 +38,11 @@ MTAnalysis >> budget: anObject [
 MTAnalysis >> classesToMutate: aClassCollection [
 
 	methodsToMutate := aClassCollection flatCollect: [ :class |
-		                   class package methodsForClass: class ]
+		                   | methods |
+		                   methods := class package methodsForClass: class.
+		                   methods addAll:
+			                   (class package methodsForClass: class class).
+		                   methods ]
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : 'MTAnalysis',
 	#superclass : 'Object',
 	#instVars : [
-		'modelClasses',
 		'methodsToMutate',
 		'operators',
 		'elapsedTime',
@@ -212,11 +211,10 @@ MTAnalysis >> methodsToMutate: anObject [
 
 { #category : 'accessing' }
 MTAnalysis >> modelClasses [
-	"Filter tests and testsResources"
 
-	^ modelClasses reject: [ :class |
-		  self testBaseClasses anySatisfy: [ :classToFilter |
-			  class includesBehavior: classToFilter ] ]
+	| classes |
+	classes := methodsToMutate collect: #methodClass.
+	^ classes copyWithoutDuplicates
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -3,6 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'modelClasses',
+		'methodsToMutate',
 		'operators',
 		'elapsedTime',
 		'mutations',
@@ -34,9 +35,10 @@ MTAnalysis >> budget: anObject [
 ]
 
 { #category : 'accessing' }
-MTAnalysis >> classesToMutate: anObject [
+MTAnalysis >> classesToMutate: aClassCollection [
 
-	modelClasses := anObject
+	methodsToMutate := aClassCollection flatCollect: [ :class |
+		                   class package methodsForClass: class ]
 ]
 
 { #category : 'accessing' }
@@ -115,7 +117,7 @@ MTAnalysis >> generateCoverageAnalysis [
 
 	logger logStartCoverageAnalysis.
 	coverageAnalysisResult := (MTCoverageAnalysis
-		                           for: self modelClasses
+		                           for: methodsToMutate
 		                           running: testCases)
 		                          run;
 		                          result
@@ -193,6 +195,18 @@ MTAnalysis >> logger: anObject [
 ]
 
 { #category : 'accessing' }
+MTAnalysis >> methodsToMutate [
+
+	^ methodsToMutate
+]
+
+{ #category : 'accessing' }
+MTAnalysis >> methodsToMutate: anObject [
+
+	methodsToMutate := anObject
+]
+
+{ #category : 'accessing' }
 MTAnalysis >> modelClasses [
 	"Filter tests and testsResources"
 
@@ -253,8 +267,8 @@ MTAnalysis >> operators: anObject [
 { #category : 'accessing' }
 MTAnalysis >> packagesToMutate: aCollectionOfPackages [
 
-	modelClasses := aCollectionOfPackages flatCollect: [ :packageName |
-		                packageName asPackage definedClasses ]
+	methodsToMutate := aCollectionOfPackages flatCollect: [ :packageName |
+		                   packageName asPackage methods ]
 ]
 
 { #category : 'computing' }

--- a/src/MuTalk-Model/MTCoverageAnalysis.class.st
+++ b/src/MuTalk-Model/MTCoverageAnalysis.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'result',
-		'classesAndMetaclasses',
 		'testCases',
 		'currentTest',
 		'testRunningElapsedTime',
@@ -29,15 +28,6 @@ MTCoverageAnalysis >> addTestsFrom: aWrapper to: methodToTestDictionary [
 				at: aWrapper reference compiledMethod
 				ifAbsentPut: [IdentitySet new])
 				addAll: aWrapper tests]
-]
-
-{ #category : 'private' }
-MTCoverageAnalysis >> classesAndMetaclasses [
-	classesAndMetaclasses isNil ifTrue:[
-		classesAndMetaclasses := (classes collect:[:aClass | aClass class]) asOrderedCollection.
-		classesAndMetaclasses addAll: classes.].
-	^classesAndMetaclasses.
-
 ]
 
 { #category : 'accessing' }
@@ -70,13 +60,11 @@ MTCoverageAnalysis >> installAll: wrappers [
 
 { #category : 'private' }
 MTCoverageAnalysis >> methodReferences [
-	^ self classesAndMetaclasses
-		inject: OrderedCollection new
-		into: [:methodReferences :aClass | 
-			methodReferences
-				addAll: (aClass selectors
-						collect: [:aSelector | RGMethodDefinition class: aClass selector: aSelector]).
-			methodReferences]
+
+	^ methods collect: [ :aMethod |
+		  RGMethodDefinition
+			  class: aMethod methodClass
+			  selector: aMethod selector ]
 ]
 
 { #category : 'private' }
@@ -108,7 +96,7 @@ MTCoverageAnalysis >> run [
 	result := MTCoverageAnalysisResult
 		          from: (self methodToTestDictionaryFrom: wrappers)
 		          elapsedTime: testRunningElapsedTime.
-	result methodReferences: (self classesAndMetaclasses flatCollect: [:cls | cls methods])
+	result methodReferences: methods
 ]
 
 { #category : 'private' }

--- a/src/MuTalk-Model/MTCoverageAnalysis.class.st
+++ b/src/MuTalk-Model/MTCoverageAnalysis.class.st
@@ -21,6 +21,21 @@ MTCoverageAnalysis class >> for: aCollectionOfMethods running: aCollectionOfTest
 		  running: aCollectionOfTestCases
 ]
 
+{ #category : 'instance creation' }
+MTCoverageAnalysis class >> forClasses: aCollectionOfClasses running: aCollectionOfTestCases [
+
+	| methodCollection |
+	methodCollection := aCollectionOfClasses flatCollect: [ :class |
+		                    | methods |
+		                    methods := class package methodsForClass: class.
+		                    methods addAll:
+			                    (class package methodsForClass: class class).
+		                    methods ].
+	^ self new
+		  initializeFor: methodCollection
+		  running: aCollectionOfTestCases
+]
+
 { #category : 'private' }
 MTCoverageAnalysis >> addTestsFrom: aWrapper to: methodToTestDictionary [ 
 	aWrapper tests notEmpty

--- a/src/MuTalk-Model/MTCoverageAnalysis.class.st
+++ b/src/MuTalk-Model/MTCoverageAnalysis.class.st
@@ -2,12 +2,12 @@ Class {
 	#name : 'MTCoverageAnalysis',
 	#superclass : 'Object',
 	#instVars : [
-		'classes',
 		'result',
 		'classesAndMetaclasses',
 		'testCases',
 		'currentTest',
-		'testRunningElapsedTime'
+		'testRunningElapsedTime',
+		'methods'
 	],
 	#category : 'MuTalk-Model-Coverage',
 	#package : 'MuTalk-Model',
@@ -15,8 +15,11 @@ Class {
 }
 
 { #category : 'instance creation' }
-MTCoverageAnalysis class >> for: aCollectionOfClasses running: aCollectionOfTestCases [
-	^self new initializeFor: aCollectionOfClasses running: aCollectionOfTestCases
+MTCoverageAnalysis class >> for: aCollectionOfMethods running: aCollectionOfTestCases [
+
+	^ self new
+		  initializeFor: aCollectionOfMethods
+		  running: aCollectionOfTestCases
 ]
 
 { #category : 'private' }
@@ -54,8 +57,9 @@ MTCoverageAnalysis >> flushMethodLookupCaches [
 ]
 
 { #category : 'initialize-release' }
-MTCoverageAnalysis >> initializeFor: aCollectionOfClasses running: aCollectionOfTestCases [ 
-	classes := aCollectionOfClasses. 
+MTCoverageAnalysis >> initializeFor: aCollectionOfMethods running: aCollectionOfTestCases [
+
+	methods := aCollectionOfMethods.
 	testCases := aCollectionOfTestCases
 ]
 

--- a/src/MuTalk-Model/MTMutantEvaluation.class.st
+++ b/src/MuTalk-Model/MTMutantEvaluation.class.st
@@ -37,11 +37,16 @@ MTMutantEvaluation >> coverageAnalysisResult [
 
 { #category : 'initialize-release' }
 MTMutantEvaluation >> initializeCoverageResultIfNil [
-	coverageAnalysisResult 
-		ifNil:[ |coverageAnalysis|
-				coverageAnalysis := MTCoverageAnalysis for: (OrderedCollection with: mutation originalClass)
-															 running: testCases. 
-				coverageAnalysisResult := coverageAnalysis run;result].
+
+	coverageAnalysisResult ifNil: [
+		| coverageAnalysis |
+		coverageAnalysis := MTCoverageAnalysis
+			                    forClasses:
+			                    (OrderedCollection with: mutation originalClass)
+			                    running: testCases.
+		coverageAnalysisResult := coverageAnalysis
+			                          run;
+			                          result ]
 ]
 
 { #category : 'initialize-release' }

--- a/src/MuTalk-TestResources/MTAuxiliarClassForAnalysisWithExtensionMethods.class.st
+++ b/src/MuTalk-TestResources/MTAuxiliarClassForAnalysisWithExtensionMethods.class.st
@@ -1,0 +1,6 @@
+Class {
+	#name : 'MTAuxiliarClassForAnalysisWithExtensionMethods',
+	#superclass : 'Object',
+	#category : 'MuTalk-TestResources',
+	#package : 'MuTalk-TestResources'
+}

--- a/src/MuTalk-TestResourcesForExtensionMethods/MTAuxiliarClassForAnalysisWithExtensionMethods.extension.st
+++ b/src/MuTalk-TestResourcesForExtensionMethods/MTAuxiliarClassForAnalysisWithExtensionMethods.extension.st
@@ -1,0 +1,5 @@
+Extension { #name : 'MTAuxiliarClassForAnalysisWithExtensionMethods' }
+
+{ #category : '*MuTalk-TestResourcesForExtensionMethods' }
+MTAuxiliarClassForAnalysisWithExtensionMethods >> extensionMethod [
+]

--- a/src/MuTalk-TestResourcesForExtensionMethods/package.st
+++ b/src/MuTalk-TestResourcesForExtensionMethods/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MuTalk-TestResourcesForExtensionMethods' }

--- a/src/MuTalk-Tests/MTAnalysisTest.class.st
+++ b/src/MuTalk-Tests/MTAnalysisTest.class.st
@@ -289,6 +289,32 @@ MTAnalysisTest >> testExecutingTwoMutations [
 ]
 
 { #category : 'tests' }
+MTAnalysisTest >> testExtensionMethodsMutatedWhenUsingPackages [
+
+	| analysis mutations selectors |
+	analysis := MTAnalysis new packagesToMutate:
+		            { 'MuTalk-TestResourcesForExtensionMethods' }.
+	mutations := analysis generateMutations.
+	selectors := mutations collect: [ :mutant |
+		             mutant originalMethod selector ].
+
+	self assert: (selectors includes: #extensionMethod)
+]
+
+{ #category : 'tests' }
+MTAnalysisTest >> testExtensionMethodsNotMutatedWhenUsingClasses [
+
+	| analysis mutations selectors |
+	analysis := MTAnalysis new classesToMutate:
+		            { MTAuxiliarClassForAnalysisWithExtensionMethods }.
+	mutations := analysis generateMutations.
+	selectors := mutations collect: [ :mutant |
+		             mutant originalMethod selector ].
+
+	self deny: (selectors includes: #extensionMethod)
+]
+
+{ #category : 'tests' }
 MTAnalysisTest >> testRunningAllTests [
 	"This test verify that the test evaluation keeps running even after the first error, if specified"
 

--- a/src/MuTalk-Tests/MTTestCoverageAnalysis.class.st
+++ b/src/MuTalk-Tests/MTTestCoverageAnalysis.class.st
@@ -8,16 +8,20 @@ Class {
 { #category : 'testing' }
 MTTestCoverageAnalysis >> testBugWhenHavingATestResourceSendingToOther [
 	"the problem was when sending from a resource a message to another object wich class is going to be considered for coverage"
-	| analysis testCases|
+
+	| analysis testCases methods |
+	methods := MTClassForTestingCoverage methods asOrderedCollection.
+	methods addAll: MTTestResourceClassForTestingCoverage methods.
 	analysis := MTCoverageAnalysis
-		for: (Array with: MTClassForTestingCoverage with:MTTestResourceClassForTestingCoverage)
-		running: MTTestClassForTestingCoverage suite tests.
+		            for: methods
+		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
-	testCases := analysis result testCasesThatCovers: MTClassForTestingCoverage class >> #aClassCoveredMethod.
-	
-	self assert: ((testCases collect: [:each | each selector]) includes:#testCaseThatCoversAClassMethod).
+	testCases := analysis result testCasesThatCovers:
+		             MTClassForTestingCoverage class >> #aClassCoveredMethod.
 
-
+	self assert:
+		((testCases collect: [ :each | each selector ]) includes:
+			 #testCaseThatCoversAClassMethod)
 ]
 
 { #category : 'testing' }
@@ -25,7 +29,7 @@ MTTestCoverageAnalysis >> testCoveredMethods [
 
 	| analysis |
 	analysis := MTCoverageAnalysis
-		            for: (Array with: MTClassForTestingCoverage)
+		            for: MTClassForTestingCoverage methods
 		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
 
@@ -38,7 +42,8 @@ MTTestCoverageAnalysis >> testCoveredMethods [
 	self deny: (analysis result uncoveredMethods includes:
 			 MTClassForTestingCoverage >> #aCoveredMethod).
 	self deny: (analysis result uncoveredMethods includes:
-			 MTClassForTestingCoverage >> #anUncoveredMethodSubClassResponsibility)		
+			 MTClassForTestingCoverage
+			 >> #anUncoveredMethodSubClassResponsibility)
 ]
 
 { #category : 'testing' }

--- a/src/MuTalk-Tests/MTTestCoverageAnalysis.class.st
+++ b/src/MuTalk-Tests/MTTestCoverageAnalysis.class.st
@@ -9,11 +9,11 @@ Class {
 MTTestCoverageAnalysis >> testBugWhenHavingATestResourceSendingToOther [
 	"the problem was when sending from a resource a message to another object wich class is going to be considered for coverage"
 
-	| analysis testCases methods |
-	methods := MTClassForTestingCoverage methods asOrderedCollection.
-	methods addAll: MTTestResourceClassForTestingCoverage methods.
+	| analysis testCases |
 	analysis := MTCoverageAnalysis
-		            for: methods
+		            forClasses: (Array
+				             with: MTClassForTestingCoverage
+				             with: MTTestResourceClassForTestingCoverage)
 		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
 	testCases := analysis result testCasesThatCovers:
@@ -29,7 +29,7 @@ MTTestCoverageAnalysis >> testCoveredMethods [
 
 	| analysis |
 	analysis := MTCoverageAnalysis
-		            for: MTClassForTestingCoverage methods
+		            forClasses: (Array with: MTClassForTestingCoverage)
 		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
 
@@ -42,33 +42,37 @@ MTTestCoverageAnalysis >> testCoveredMethods [
 	self deny: (analysis result uncoveredMethods includes:
 			 MTClassForTestingCoverage >> #aCoveredMethod).
 	self deny: (analysis result uncoveredMethods includes:
-			 MTClassForTestingCoverage
-			 >> #anUncoveredMethodSubClassResponsibility)
+			 MTClassForTestingCoverage >> #anUncoveredMethodSubClassResponsibility)		
 ]
 
 { #category : 'testing' }
 MTTestCoverageAnalysis >> testGettingTheTestCasesThatCoverAClassMethod [
-	| analysis testCases|
+
+	| analysis testCases |
 	analysis := MTCoverageAnalysis
-		for: (Array with: MTClassForTestingCoverage)
-		running: MTTestClassForTestingCoverage suite tests.
+		            forClasses: (Array with: MTClassForTestingCoverage)
+		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
-	testCases := analysis result testCasesThatCovers: MTClassForTestingCoverage class >> #aClassCoveredMethod.
-	
-	self assert: ((testCases collect: [:each | each selector]) includes:#testCaseThatCoversAClassMethod).
+	testCases := analysis result testCasesThatCovers:
+		             MTClassForTestingCoverage class >> #aClassCoveredMethod.
 
-
+	self assert:
+		((testCases collect: [ :each | each selector ]) includes:
+			 #testCaseThatCoversAClassMethod)
 ]
 
 { #category : 'testing' }
 MTTestCoverageAnalysis >> testGettingTheTestCasesThatCoverAMethod [
-	| analysis testCases|
 
-	analysis := MTCoverageAnalysis 
-		for: (Array with: MTClassForTestingCoverage)
-		running: MTTestClassForTestingCoverage suite tests.
+	| analysis testCases |
+	analysis := MTCoverageAnalysis
+		            forClasses: (Array with: MTClassForTestingCoverage)
+		            running: MTTestClassForTestingCoverage suite tests.
 	analysis run.
-	testCases := analysis result testCasesThatCovers: MTClassForTestingCoverage >> #aCoveredMethod.
-	self assert: ((testCases collect: [:each | each selector]) includes:#testCase1).
-	self deny: ((testCases collect: [:each | each selector]) includes:#testCase3).
+	testCases := analysis result testCasesThatCovers:
+		             MTClassForTestingCoverage >> #aCoveredMethod.
+	self assert:
+		((testCases collect: [ :each | each selector ]) includes: #testCase1).
+	self deny:
+		((testCases collect: [ :each | each selector ]) includes: #testCase3)
 ]

--- a/src/MuTalk-Utilities-Tests/MTNonMutatedMethodsAnalysisTest.class.st
+++ b/src/MuTalk-Utilities-Tests/MTNonMutatedMethodsAnalysisTest.class.st
@@ -14,9 +14,9 @@ MTNonMutatedMethodsAnalysisTest >> testNonMutatedMethods [
 	analysis mtAnalysis operators: {
 			MTReplacePlusWithMinusMutantOperator new.
 			MTReplaceMinusWithPlusMutantOperator new }.
-	results := analysis methodsWithoutMutation.
+	results := analysis methodsWithoutMutation asSet.
 
 	self assert: results equals: {
 			(MTAuxiliarClassForMatrix >> #initialize).
-			(MTAuxiliarClassForMatrix >> #reset) } asOrderedCollection
+			(MTAuxiliarClassForMatrix >> #reset) } asSet
 ]

--- a/src/MuTalk-Utilities-Tests/MTNonMutatedMethodsAnalysisTest.class.st
+++ b/src/MuTalk-Utilities-Tests/MTNonMutatedMethodsAnalysisTest.class.st
@@ -8,13 +8,15 @@ Class {
 { #category : 'tests' }
 MTNonMutatedMethodsAnalysisTest >> testNonMutatedMethods [
 
-	| results |
-	results := (MTNonMutatedMethodsAnalysis forClasses: {
-			            MTAuxiliarClassForMatrix.
-			            MTAuxiliarClassForMatrixTest })
-		           methodsWithoutMutation asSet.
+	| analysis results |
+	analysis := (MTNonMutatedMethodsAnalysis forClasses:
+		             { MTAuxiliarClassForMatrix }) initializeMtAnalysis.
+	analysis mtAnalysis operators: {
+			MTReplacePlusWithMinusMutantOperator new.
+			MTReplaceMinusWithPlusMutantOperator new }.
+	results := analysis methodsWithoutMutation.
 
-	self
-		assert: results
-		equals: MTAuxiliarClassForMatrixTest methods asSet
+	self assert: results equals: {
+			(MTAuxiliarClassForMatrix >> #initialize).
+			(MTAuxiliarClassForMatrix >> #reset) } asOrderedCollection
 ]

--- a/src/MuTalk-Utilities/MTMutantOperatorAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTMutantOperatorAnalysis.class.st
@@ -41,14 +41,12 @@ MTMutantOperatorAnalysis >> operatorDictionary [
 { #category : 'computing' }
 MTMutantOperatorAnalysis >> operatorDictionaryFromAnalysis [
 
-	| analysis dic |
-	analysis := MTAnalysis new
-		            classesToMutate: classes;
-		            testClasses: {  }.
+	|  dic |
+	self initializeMtAnalysis.
 
-	analysis generateMutations.
+	mtAnalysis generateMutations.
 
-	^ dic := (analysis mutations groupedBy: [ :e | e operator species ])
+	^ dic := (mtAnalysis mutations groupedBy: [ :e | e operator species ])
 		         collect: [ :coll | coll size ]
 ]
 

--- a/src/MuTalk-Utilities/MTNonMutatedMethodsAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTNonMutatedMethodsAnalysis.class.st
@@ -26,13 +26,11 @@ MTNonMutatedMethodsAnalysis >> methodsWithoutMutation [
 { #category : 'computing' }
 MTNonMutatedMethodsAnalysis >> mutatedMethods [
 
-	| analysis mutatedMethods |
-	analysis := MTAnalysis new
-		            classesToMutate: classes;
-		            testClasses: {  }.
+	| mutatedMethods |
+	self initializeMtAnalysis.
 
 	mutatedMethods := Set withAll:
-		                  (analysis generateMutations collect:
+		                  (mtAnalysis generateMutations collect:
 			                   #originalMethod).
 	^ mutatedMethods
 ]

--- a/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : 'MTUtilityAnalysis',
 	#superclass : 'Object',
 	#instVars : [
-		'classes'
+		'classes',
+		'mtAnalysis'
 	],
 	#category : 'MuTalk-Utilities',
 	#package : 'MuTalk-Utilities'
@@ -37,4 +38,19 @@ MTUtilityAnalysis >> classes [
 MTUtilityAnalysis >> classes: anObject [
 
 	classes := anObject
+]
+
+{ #category : 'initialization' }
+MTUtilityAnalysis >> initializeMtAnalysis [
+
+	mtAnalysis ifNil: [
+		mtAnalysis := MTAnalysis new
+			              classesToMutate: classes;
+			              testClasses: {  } ]
+]
+
+{ #category : 'accessing' }
+MTUtilityAnalysis >> mtAnalysis [
+
+	^ mtAnalysis
 ]


### PR DESCRIPTION
Fixes #30
Refactored `MTAnalysis` and `MTCoverageAnalysis` to use methods instead of classes.
Also, extension methods are now not mutated when using classes (`classesToMutate:) ` with `MTAnalysis`, but are when using packages (`packagesToMutate:`).