### PR TITLE
Example for the MuTalk chapter and small changes

### DIFF
--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -7,24 +7,27 @@ Class {
 
 { #category : 'baselines' }
 BaselineOfMuTalk >> baseline: spec [
-	<baseline>
 
+	<baseline>
 	spec for: #common do: [
 		spec
-		   package: 'TestCoverage';
+			package: 'TestCoverage';
 			package: 'MuTalk-Model' with: [ spec requires: #( 'TestCoverage' ) ];
 			package: 'MuTalk-TestResources' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-TestResourcesForExtensionMethods' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
 			package: 'MuTalk-CI' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-CI-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-CI' ) ];
-			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods') ];
-			package: 'MuTalk-SpecUI' with: [ spec requires: #('MuTalk-Model') ];
+			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods' ) ];
+			package: 'MuTalk-SpecUI' with: [ spec requires: #( 'MuTalk-Model' ) ];
 			package: 'MuTalk-Utilities' with: [ spec requires: #( 'MuTalk-Model' ) ];
-			package: 'MuTalk-Utilities-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ].
+			package: 'MuTalk-Utilities-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ];
+			package: 'MuTalk-Examples' with: [ spec requires: #( 'MuTalk-Model' ) ].
 
 		spec
 			group: 'default'
-			with:
-				#( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods' 'MuTalk-Tests'
-				   'MuTalk-CI' 'MuTalk-CI-Tests' 'MuTalk-SpecUI' 'MuTalk-Utilities' 'MuTalk-Utilities-Tests' ) ]
+			with: #( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources'
+				   'MuTalk-TestResourcesForExtensionMethods'
+				   'MuTalk-Tests' 'MuTalk-CI' 'MuTalk-CI-Tests' 'MuTalk-SpecUI'
+				   'MuTalk-Utilities' 'MuTalk-Utilities-Tests'
+				   'MuTalk-Examples' ) ]
 ]

--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'MTAnalysis' }
 
 { #category : '*MuTalk-Examples' }
-MTAnalysis class >> exampleMyVehicle [
+MTAnalysis class >> exampleAnalysis [
 
 	<script>
 	| analysis |
@@ -11,4 +11,47 @@ MTAnalysis class >> exampleMyVehicle [
 
 	analysis run.
 	analysis generalResult inspect
+]
+
+{ #category : '*MuTalk-Examples' }
+MTAnalysis class >> exampleAnalysisWithLessOperators [
+
+	<script>
+	| mtAnalysis removedOperators nonMutatedAnalysis |
+	mtAnalysis := self new.
+	mtAnalysis classesToMutate: { MyVehicle }.
+	mtAnalysis testClasses: { MyVehicleTest }.
+
+	removedOperators := { MTEmptyMethodOperator }.
+	mtAnalysis operators:
+		(MTAbstractMutantOperator contents reject: [ :operator |
+			 removedOperators includes: operator class ]).
+
+	mtAnalysis run.
+	mtAnalysis generalResult inspect.
+
+	"How to get non mutated methods:"
+	"nonMutatedAnalysis := MTNonMutatedMethodsAnalysis forClasses: { MyVehicle }.
+	nonMutatedAnalysis mtAnalysis: mtAnalysis.
+	nonMutatedAnalysis methodsWithoutMutation inspect"
+]
+
+{ #category : '*MuTalk-Examples' }
+MTAnalysis class >> exampleWithHeatmap [
+
+	<script>
+	| matrix |
+	matrix := MTMatrix forClasses: { MyVehicle }.
+	matrix build.
+	matrix generateHeatmap
+]
+
+{ #category : '*MuTalk-Examples' }
+MTAnalysis class >> exampleWithMatrix [
+
+	<script>
+	| matrix |
+	matrix := MTMatrix forClasses: { MyVehicle }.
+	matrix build.
+	matrix generateMatrix
 ]

--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -30,7 +30,8 @@ MTAnalysis class >> exampleAnalysisWithLessOperators [
 	mtAnalysis run.
 	mtAnalysis generalResult inspect.
 
-	"How to get non mutated methods:"
+	"Uncomment the following instructions to get non mutated methods"
+	
 	"nonMutatedAnalysis := MTNonMutatedMethodsAnalysis forClasses: { MyVehicle }.
 	nonMutatedAnalysis mtAnalysis: mtAnalysis.
 	nonMutatedAnalysis methodsWithoutMutation inspect"

--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'MTAnalysis' }
+
+{ #category : '*MuTalk-Examples' }
+MTAnalysis class >> exampleMyVehicle [
+
+	<script>
+	| analysis |
+	analysis := self new.
+	analysis classesToMutate: { MyVehicle }.
+	analysis testClasses: { MyVehicleTest }.
+
+	analysis run.
+	analysis generalResult inspect
+]

--- a/src/MuTalk-Examples/MyVehicle.class.st
+++ b/src/MuTalk-Examples/MyVehicle.class.st
@@ -1,0 +1,65 @@
+Class {
+	#name : 'MyVehicle',
+	#superclass : 'Object',
+	#instVars : [
+		'numberOfWheels',
+		'numberOfSeats'
+	],
+	#category : 'MuTalk-Examples',
+	#package : 'MuTalk-Examples'
+}
+
+{ #category : 'instance creation' }
+MyVehicle class >> newSimpleCar [
+
+	^ self new initializeWithNumberOfWheels: 4 andNumberOfSeats: 5
+]
+
+{ #category : 'instance creation' }
+MyVehicle class >> newWithSeats: aNumber [
+
+	^ self new initializeWithNumberOfWheels: 0 andNumberOfSeats: aNumber
+]
+
+{ #category : 'instance creation' }
+MyVehicle class >> newWithWheels: aNumber [
+
+	^ self new initializeWithNumberOfWheels: aNumber andNumberOfSeats: 0
+]
+
+{ #category : 'testing' }
+MyVehicle >> hasFourWheels [
+
+	^ self numberOfWheels = 4
+]
+
+{ #category : 'initialization' }
+MyVehicle >> initializeWithNumberOfWheels: aNumberOfWheels andNumberOfSeats: aNumberOfSeats [
+
+	self numberOfWheels: aNumberOfWheels.
+	self numberOfSeats: aNumberOfSeats
+]
+
+{ #category : 'accessing' }
+MyVehicle >> numberOfSeats [
+
+	^ numberOfSeats
+]
+
+{ #category : 'accessing' }
+MyVehicle >> numberOfSeats: aNumber [
+
+	numberOfSeats := aNumber
+]
+
+{ #category : 'accessing' }
+MyVehicle >> numberOfWheels [
+
+	^ numberOfWheels
+]
+
+{ #category : 'accessing' }
+MyVehicle >> numberOfWheels: aNumber [
+
+	numberOfWheels := aNumber
+]

--- a/src/MuTalk-Examples/MyVehicle.class.st
+++ b/src/MuTalk-Examples/MyVehicle.class.st
@@ -5,29 +5,34 @@ Class {
 	#name : 'MyVehicle',
 	#superclass : 'Object',
 	#instVars : [
-		'numberOfWheels',
-		'numberOfSeats'
+		'numberOfWheels'
 	],
 	#category : 'MuTalk-Examples',
 	#package : 'MuTalk-Examples'
 }
 
 { #category : 'instance creation' }
-MyVehicle class >> newSimpleCar [
+MyVehicle class >> newBike [
 
-	^ self new initializeWithNumberOfWheels: 4 andNumberOfSeats: 5
+	^ self new initializeWithNumberOfWheels: 2
 ]
 
 { #category : 'instance creation' }
-MyVehicle class >> newWithSeats: aNumber [
+MyVehicle class >> newSimpleCar [
 
-	^ self new initializeWithNumberOfWheels: 0 andNumberOfSeats: aNumber
+	^ self new initializeWithNumberOfWheels: 4
 ]
 
 { #category : 'instance creation' }
 MyVehicle class >> newWithWheels: aNumber [
 
-	^ self new initializeWithNumberOfWheels: aNumber andNumberOfSeats: 0
+	^ self new initializeWithNumberOfWheels: aNumber
+]
+
+{ #category : 'as yet unclassified' }
+MyVehicle >> emptyMethod [
+
+	
 ]
 
 { #category : 'testing' }
@@ -37,22 +42,9 @@ MyVehicle >> hasFourWheels [
 ]
 
 { #category : 'initialization' }
-MyVehicle >> initializeWithNumberOfWheels: aNumberOfWheels andNumberOfSeats: aNumberOfSeats [
+MyVehicle >> initializeWithNumberOfWheels: aNumberOfWheels [
 
-	self numberOfWheels: aNumberOfWheels.
-	self numberOfSeats: aNumberOfSeats
-]
-
-{ #category : 'accessing' }
-MyVehicle >> numberOfSeats [
-
-	^ numberOfSeats
-]
-
-{ #category : 'accessing' }
-MyVehicle >> numberOfSeats: aNumber [
-
-	numberOfSeats := aNumber
+	self numberOfWheels: aNumberOfWheels
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Examples/MyVehicle.class.st
+++ b/src/MuTalk-Examples/MyVehicle.class.st
@@ -1,3 +1,6 @@
+"
+This class serves only as an example in the MuTalk chapter.
+"
 Class {
 	#name : 'MyVehicle',
 	#superclass : 'Object',

--- a/src/MuTalk-Examples/MyVehicleTest.class.st
+++ b/src/MuTalk-Examples/MyVehicleTest.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : 'MyVehicleTest',
+	#superclass : 'TestCase',
+	#category : 'MuTalk-Examples',
+	#package : 'MuTalk-Examples'
+}
+
+{ #category : 'tests' }
+MyVehicleTest >> testHasFiveSeats [
+
+	| aVehicle |
+	aVehicle := MyVehicle newWithSeats: 5.
+	self assert: aVehicle numberOfSeats equals: 5
+]
+
+{ #category : 'tests' }
+MyVehicleTest >> testHasFourWheels [
+
+	| aVehicle |
+	aVehicle := MyVehicle newWithWheels: 4.
+	self assert: aVehicle hasFourWheels
+]
+
+{ #category : 'tests' }
+MyVehicleTest >> testSimpleCarHasFourWheelsAndFiveSeats [
+
+	| car |
+	car := MyVehicle newSimpleCar.
+	self assert: car hasFourWheels.
+	self assert: car numberOfSeats equals: 5
+]

--- a/src/MuTalk-Examples/MyVehicleTest.class.st
+++ b/src/MuTalk-Examples/MyVehicleTest.class.st
@@ -6,11 +6,11 @@ Class {
 }
 
 { #category : 'tests' }
-MyVehicleTest >> testHasFiveSeats [
+MyVehicleTest >> testBikeHasTwoWheels [
 
-	| aVehicle |
-	aVehicle := MyVehicle newWithSeats: 5.
-	self assert: aVehicle numberOfSeats equals: 5
+	| bike |
+	bike := MyVehicle newBike.
+	self assert: bike numberOfWheels equals: 2
 ]
 
 { #category : 'tests' }
@@ -22,10 +22,9 @@ MyVehicleTest >> testHasFourWheels [
 ]
 
 { #category : 'tests' }
-MyVehicleTest >> testSimpleCarHasFourWheelsAndFiveSeats [
+MyVehicleTest >> testSimpleCarHasFourWheels [
 
 	| car |
 	car := MyVehicle newSimpleCar.
-	self assert: car hasFourWheels.
-	self assert: car numberOfSeats equals: 5
+	self assert: car hasFourWheels
 ]

--- a/src/MuTalk-Examples/package.st
+++ b/src/MuTalk-Examples/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MuTalk-Examples' }

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -129,8 +129,8 @@ MTAnalysis >> generateCoverageAnalysis [
 { #category : 'running' }
 MTAnalysis >> generateMutations [
 
-	logger logStartMutationGeneration: self methodSize.
 	^ mutations ifNil: [
+		  logger logStartMutationGeneration: self methodSize.
 		  mutations := mutantGenerationStrategy
 			               mutationsFor: self
 			               loggingIn: logger.

--- a/src/MuTalk-Tests/MTTimeBudgetTest.class.st
+++ b/src/MuTalk-Tests/MTTimeBudgetTest.class.st
@@ -56,7 +56,7 @@ MTTimeBudgetTest >> testWithNoTimeForMutantsRunsNoMutants [
 
 	| duration analysisTime result |
 	"Divide duration by 4 to make sure we never have time for mutants"
-	duration := self fixedAnalysisTime / 4.
+	duration := self fixedAnalysisTime / 10.
 	analysisTime := [ result := self runAnalysisForDuration: duration ]
 		                timeToRun.
 

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -210,6 +210,8 @@ MTMatrix >> generateHeatmap [
 	heatmap dataMatrix: (self
 			 dataMatrixForTests: testDictionary
 			 andMutations: mutationDictionary).
+	"the data change the color palette domain, but we want it to be from 0 to 100"
+	heatmap colorPalette domain: { 0. 50. 100 }.
 
 	heatmap open
 ]
@@ -245,8 +247,9 @@ MTMatrix >> initializeHeatmap [
 	heatmap labelShapeCell labelShape bold.
 	heatmap shape extent: 50 @ 20.
 	heatmap colorPalette: (NSScale linear range: {
+				 Color red.
 				 Color yellow.
-				 Color red }).
+				 Color green }).
 	^ heatmap
 ]
 

--- a/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
@@ -54,3 +54,9 @@ MTUtilityAnalysis >> mtAnalysis [
 
 	^ mtAnalysis
 ]
+
+{ #category : 'accessing' }
+MTUtilityAnalysis >> mtAnalysis: anAnalysis [
+
+	mtAnalysis := anAnalysis
+]


### PR DESCRIPTION
Package `MuTalk-Examples` contains a class and a test class used for the MuTalk chapter, and executable scripts as extension methods in `MTAnalysis` class side.

Small changes include :
- don't log the mutant generation if the mutations are already given (mutations are not nil)
- heat map color palette changed to red - yellow - green
- setter for `mtAnalysis` in `MTUtilityAnalysis` class