### PR TITLE
Utility analysis ignore the "no tests" warning

### DIFF
--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -14,7 +14,8 @@ Class {
 		'stopOnErrorOrFail',
 		'testSelectionStrategy',
 		'testFilter',
-		'mutantGenerationStrategy'
+		'mutantGenerationStrategy',
+		'warnAboutEmptyTests'
 	],
 	#category : 'MuTalk-Model-Core',
 	#package : 'MuTalk-Model',
@@ -105,6 +106,12 @@ MTAnalysis >> doNotStopOnErrorOrFail [
 	stopOnErrorOrFail := false
 ]
 
+{ #category : 'accessing' }
+MTAnalysis >> doNotWarnAboutEmptyTests [
+
+	warnAboutEmptyTests := false
+]
+
 { #category : 'results' }
 MTAnalysis >> generalResult [
 
@@ -191,7 +198,8 @@ MTAnalysis >> initialize [
 	elapsedTime := 0.
 	logger := self defaultLogger.
 	stopOnErrorOrFail := true.
-	budget := self defaultBudget
+	budget := self defaultBudget.
+	warnAboutEmptyTests := true
 ]
 
 { #category : 'accessing' }
@@ -362,7 +370,7 @@ MTAnalysis >> testCasesFrom: aClassCollection [
 				         testCase addAll:
 					         (self testCasesReferencesFrom: testClass) ].
 			         testCase ].
-	tests isEmpty ifTrue: [
+	tests isEmpty & warnAboutEmptyTests ifTrue: [
 		Warning signal: 'There is currently no tests' ].
 	^ tests
 ]

--- a/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
@@ -49,7 +49,7 @@ MTUtilityAnalysis >> initializeMtAnalysis [
 			              testClasses: {  } ]
 			on: Warning
 			do: [ :warning |
-				warning messageText = 'There is currently o tests'
+				warning messageText = 'There is currently no tests'
 					ifTrue: [ warning resume ]
 					ifFalse: [ warning signal ] ] ]
 ]

--- a/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
@@ -44,14 +44,10 @@ MTUtilityAnalysis >> classes: anObject [
 MTUtilityAnalysis >> initializeMtAnalysis [
 
 	mtAnalysis ifNil: [
-		[ mtAnalysis := MTAnalysis new
+		mtAnalysis := MTAnalysis new
 			              classesToMutate: classes;
+			              doNotWarnAboutEmptyTests;
 			              testClasses: {  } ]
-			on: Warning
-			do: [ :warning |
-				warning messageText = 'There is currently no tests'
-					ifTrue: [ warning resume ]
-					ifFalse: [ warning signal ] ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
+++ b/src/MuTalk-Utilities/MTUtilityAnalysis.class.st
@@ -44,9 +44,14 @@ MTUtilityAnalysis >> classes: anObject [
 MTUtilityAnalysis >> initializeMtAnalysis [
 
 	mtAnalysis ifNil: [
-		mtAnalysis := MTAnalysis new
+		[ mtAnalysis := MTAnalysis new
 			              classesToMutate: classes;
 			              testClasses: {  } ]
+			on: Warning
+			do: [ :warning |
+				warning messageText = 'There is currently o tests'
+					ifTrue: [ warning resume ]
+					ifFalse: [ warning signal ] ] ]
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Fixes #123 
Those analysis don't use tests, so the warning should not interrupt them.  
The current solution is certainly not perfect, so I'm open to better implementation idea.