### PR TITLE
Mutant selection strategies more easily accessible and method rename

### DIFF
--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -130,7 +130,7 @@ MTAnalysis >> generateCoverageAnalysis [
 MTAnalysis >> generateMutations [
 
 	^ mutations ifNil: [
-		  logger logStartMutationGeneration: self methodSize.
+		  logger logStartMutationGeneration: self methodsCount.
 		  mutations := mutantGenerationStrategy
 			               mutationsFor: self
 			               loggingIn: logger.
@@ -208,8 +208,8 @@ MTAnalysis >> logger: anObject [
 	logger := anObject
 ]
 
-{ #category : 'as yet unclassified' }
-MTAnalysis >> methodSize [
+{ #category : 'accessing' }
+MTAnalysis >> methodsCount [
 
 	^ (self modelClasses flatCollect: #methods) size
 ]

--- a/src/MuTalk-Model/MTAnalysis.class.st
+++ b/src/MuTalk-Model/MTAnalysis.class.st
@@ -253,6 +253,18 @@ MTAnalysis >> mutantResults [
 ]
 
 { #category : 'accessing' }
+MTAnalysis >> mutantSelectionStrategy [
+
+	^ mutantGenerationStrategy mutantSelectionStrategy
+]
+
+{ #category : 'accessing' }
+MTAnalysis >> mutantSelectionStrategy: anObject [
+
+	mutantGenerationStrategy mutantSelectionStrategy: anObject
+]
+
+{ #category : 'accessing' }
 MTAnalysis >> mutations [
 
 	^ mutations


### PR DESCRIPTION
Added accessors methods to mutant selection strategies for `MTAnalysis`, even though they are attributes of mutant *generation* strategies, to make them easier to manipulate from the analysis object.  
Also renamed a method with unclear name.