### PR TITLE
More customizable heatmaps

### DIFF
--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -44,7 +44,7 @@ MTAnalysis class >> exampleWithHeatmap [
 	| matrix |
 	matrix := MTMatrix forClasses: { MyVehicle }.
 	matrix build.
-	matrix generateHeatmap
+	matrix generateHeatmapWithMutationsGroupedByOperator
 ]
 
 { #category : '*MuTalk-Examples' }

--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -44,7 +44,7 @@ MTAnalysis class >> exampleWithHeatmap [
 	| matrix |
 	matrix := MTMatrix forClasses: { MyVehicle }.
 	matrix build.
-	matrix generateHeatmapWithMutationsGroupedByMethod
+	matrix generateHeatmapByMethod
 ]
 
 { #category : '*MuTalk-Examples' }

--- a/src/MuTalk-Examples/MTAnalysis.extension.st
+++ b/src/MuTalk-Examples/MTAnalysis.extension.st
@@ -44,7 +44,7 @@ MTAnalysis class >> exampleWithHeatmap [
 	| matrix |
 	matrix := MTMatrix forClasses: { MyVehicle }.
 	matrix build.
-	matrix generateHeatmapWithMutationsGroupedByOperator
+	matrix generateHeatmapWithMutationsGroupedByMethod
 ]
 
 { #category : '*MuTalk-Examples' }

--- a/src/MuTalk-Utilities/MTAnalysis.extension.st
+++ b/src/MuTalk-Utilities/MTAnalysis.extension.st
@@ -1,11 +1,27 @@
 Extension { #name : 'MTAnalysis' }
 
 { #category : '*MuTalk-Utilities' }
-MTAnalysis >> generateHeatmap [
+MTAnalysis >> generateHeatmapByClass [
 
 	| matrix |
 	matrix := MTMatrix new analysis: self.
-	matrix generateHeatmap
+	matrix generateHeatmapByClass
+]
+
+{ #category : '*MuTalk-Utilities' }
+MTAnalysis >> generateHeatmapByMethod [
+
+	| matrix |
+	matrix := MTMatrix new analysis: self.
+	matrix generateHeatmapByMethod
+]
+
+{ #category : '*MuTalk-Utilities' }
+MTAnalysis >> generateHeatmapByOperator [
+
+	| matrix |
+	matrix := MTMatrix new analysis: self.
+	matrix generateHeatmapByOperator
 ]
 
 { #category : '*MuTalk-Utilities' }

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -213,6 +213,27 @@ MTMatrix >> fillMatrix [
 ]
 
 { #category : 'rendering' }
+MTMatrix >> generateHeatmapByClass [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation originalClass ]
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmapByMethod [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation originalMethod name ]
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmapByOperator [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation operator species ]
+]
+
+{ #category : 'rendering' }
 MTMatrix >> generateHeatmapWithMutationsGroupedBy: aBlock [
 
 	| heatmap mutationDictionary testDictionary |
@@ -230,27 +251,6 @@ MTMatrix >> generateHeatmapWithMutationsGroupedBy: aBlock [
 	heatmap colorPalette domain: { 0. 50. 100 }.
 
 	heatmap open
-]
-
-{ #category : 'rendering' }
-MTMatrix >> generateHeatmapWithMutationsGroupedByClass [
-
-	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
-		mutation originalClass ]
-]
-
-{ #category : 'rendering' }
-MTMatrix >> generateHeatmapWithMutationsGroupedByMethod [
-
-	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
-		mutation originalMethod name ]
-]
-
-{ #category : 'rendering' }
-MTMatrix >> generateHeatmapWithMutationsGroupedByOperator [
-
-	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
-		mutation operator species ]
 ]
 
 { #category : 'rendering' }

--- a/src/MuTalk-Utilities/MTMatrix.class.st
+++ b/src/MuTalk-Utilities/MTMatrix.class.st
@@ -196,11 +196,10 @@ MTMatrix >> failuresFor: aMutation andTestClass: aTestClass [
 ]
 
 { #category : 'rendering' }
-MTMatrix >> generateHeatmap [
+MTMatrix >> generateHeatmapWithMutationsGroupedBy: aBlock [
 
 	| heatmap mutationDictionary testDictionary |
-	mutationDictionary := mutations groupedBy: [ :mutation |
-		                      mutation operator species ].
+	mutationDictionary := mutations groupedBy: aBlock.
 	testDictionary := testCases groupedBy: #testCaseClass.
 
 	heatmap := self initializeHeatmap.
@@ -214,6 +213,27 @@ MTMatrix >> generateHeatmap [
 	heatmap colorPalette domain: { 0. 50. 100 }.
 
 	heatmap open
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmapWithMutationsGroupedByClass [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation originalClass ]
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmapWithMutationsGroupedByMethod [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation originalMethod name ]
+]
+
+{ #category : 'rendering' }
+MTMatrix >> generateHeatmapWithMutationsGroupedByOperator [
+
+	self generateHeatmapWithMutationsGroupedBy: [ :mutation |
+		mutation operator species ]
 ]
 
 { #category : 'rendering' }


### PR DESCRIPTION
Changed heatmap generation to be able to group mutations by whichever block is given.
Added three configurations : mutations grouped by operator (the previous default), by class or by method.