### PR TITLE
Moved MyVehicleTest to dedicated test package

### DIFF
--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -42,5 +42,6 @@ BaselineOfMuTalk >> baseline: spec [
 			with: #( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources'
 				   'MuTalk-TestResourcesForExtensionMethods'
 				   'MuTalk-Tests' 'MuTalk-CI' 'MuTalk-CI-Tests' 'MuTalk-SpecUI'
-				   'MuTalk-Utilities' 'MuTalk-Utilities-Tests' ) ]
+				   'MuTalk-Utilities' 'MuTalk-Utilities-Tests'
+				   'Examples' ) ]
 ]

--- a/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
+++ b/src/BaselineOfMuTalk/BaselineOfMuTalk.class.st
@@ -12,22 +12,35 @@ BaselineOfMuTalk >> baseline: spec [
 	spec for: #common do: [
 		spec
 			package: 'TestCoverage';
-			package: 'MuTalk-Model' with: [ spec requires: #( 'TestCoverage' ) ];
-			package: 'MuTalk-TestResources' with: [ spec requires: #( 'MuTalk-Model' ) ];
-			package: 'MuTalk-TestResourcesForExtensionMethods' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
+			package: 'MuTalk-Model'
+			with: [ spec requires: #( 'TestCoverage' ) ];
+			package: 'MuTalk-TestResources'
+			with: [ spec requires: #( 'MuTalk-Model' ) ];
+			package: 'MuTalk-TestResourcesForExtensionMethods'
+			with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' ) ];
 			package: 'MuTalk-CI' with: [ spec requires: #( 'MuTalk-Model' ) ];
-			package: 'MuTalk-CI-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-CI' ) ];
-			package: 'MuTalk-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods' ) ];
-			package: 'MuTalk-SpecUI' with: [ spec requires: #( 'MuTalk-Model' ) ];
-			package: 'MuTalk-Utilities' with: [ spec requires: #( 'MuTalk-Model' ) ];
-			package: 'MuTalk-Utilities-Tests' with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ];
-			package: 'MuTalk-Examples' with: [ spec requires: #( 'MuTalk-Model' ) ].
+			package: 'MuTalk-CI-Tests'
+			with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-CI' ) ];
+			package: 'MuTalk-Tests' with: [
+				spec requires:
+						#( 'MuTalk-Model' 'MuTalk-TestResources' 'MuTalk-TestResourcesForExtensionMethods' ) ];
+			package: 'MuTalk-SpecUI'
+			with: [ spec requires: #( 'MuTalk-Model' ) ];
+			package: 'MuTalk-Utilities'
+			with: [ spec requires: #( 'MuTalk-Model' ) ];
+			package: 'MuTalk-Utilities-Tests'
+			with: [ spec requires: #( 'MuTalk-Model' 'MuTalk-Utilities' ) ];
+			package: 'MuTalk-Examples'
+			with: [ spec requires: #( 'MuTalk-Model' ) ];
+			package: 'MuTalk-Examples-Tests'
+			with: [ spec requires: #( 'MuTalk-Examples' ) ].
 
 		spec
+			group: 'Examples'
+			with: #( 'MuTalk-Examples' 'MuTalk-Examples-Tests' );
 			group: 'default'
 			with: #( 'TestCoverage' 'MuTalk-Model' 'MuTalk-TestResources'
 				   'MuTalk-TestResourcesForExtensionMethods'
 				   'MuTalk-Tests' 'MuTalk-CI' 'MuTalk-CI-Tests' 'MuTalk-SpecUI'
-				   'MuTalk-Utilities' 'MuTalk-Utilities-Tests'
-				   'MuTalk-Examples' ) ]
+				   'MuTalk-Utilities' 'MuTalk-Utilities-Tests' ) ]
 ]

--- a/src/MuTalk-Examples-Tests/MyVehicleTest.class.st
+++ b/src/MuTalk-Examples-Tests/MyVehicleTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'MyVehicleTest',
 	#superclass : 'TestCase',
-	#category : 'MuTalk-Examples',
-	#package : 'MuTalk-Examples'
+	#category : 'MuTalk-Examples-Tests',
+	#package : 'MuTalk-Examples-Tests'
 }
 
 { #category : 'tests' }

--- a/src/MuTalk-Examples-Tests/package.st
+++ b/src/MuTalk-Examples-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MuTalk-Examples-Tests' }


### PR DESCRIPTION
Also wondering if examples packages should be loaded by default in MuTalk or not. They can be useful for new users to see what an analysis looks like, but past that they're not necessary to have.